### PR TITLE
[FIX] 부트캠프 개별 조회 시 시간표 응답 추가

### DIFF
--- a/src/main/java/com/planit/planit/domain/bootcamp/service/BootcampService.java
+++ b/src/main/java/com/planit/planit/domain/bootcamp/service/BootcampService.java
@@ -41,7 +41,17 @@ public class BootcampService {
     if (bootcamp == null) {
       throw new BootcampNotFoundException("ID가 " + id + "인 부트캠프를 찾을 수 없습니다.");
     }
-    return toResponseDTO(bootcamp);
+    BootcampResponseDTO response = toResponseDTO(bootcamp);
+
+    // 단건 조회 시 세션에서 classDate를 추출하여 classDates에 채움
+    List<SessionDTO> sessions = sessionMapper.findByBootcampId(id);
+    if (sessions != null && !sessions.isEmpty()) {
+      List<LocalDate> classDates =
+          sessions.stream().map(SessionDTO::getClassDate).sorted().collect(Collectors.toList());
+      response.setClassDates(classDates);
+    }
+
+    return response;
   }
 
   @Transactional


### PR DESCRIPTION
## ✨ 이 PR의 목적
- 부트캠프 조회 시 시간표가 포함되지 않음.
## 📄 작업 내용 요약
- 부트캠프 개별 조회 시 시간표 응답 추가
## 📎 Issue 번호
- Close: #15 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정

* 부트캠프 상세 조회 시 해당 부트캠프와 연관된 모든 강의 일정 정보가 응답에 포함되어 제공됩니다. 강의 일정은 날짜 기준으로 정렬되어 반환되므로 일정 관리가 더욱 편리해집니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->