### PR TITLE
[FEAT] 시간표 관리 기능 추가

### DIFF
--- a/src/main/java/com/planit/planit/domain/bootcamp/dto/BootcampDTO.java
+++ b/src/main/java/com/planit/planit/domain/bootcamp/dto/BootcampDTO.java
@@ -14,6 +14,8 @@ public class BootcampDTO {
   private String name;
   private String organizer;
   private Boolean isKdt;
+  private LocalDate startedAt;
+  private LocalDate endedAt;
   private List<LocalDate> classDates;
   private OffsetDateTime createdAt;
   private OffsetDateTime updatedAt;

--- a/src/main/java/com/planit/planit/domain/bootcamp/dto/BootcampResponseDTO.java
+++ b/src/main/java/com/planit/planit/domain/bootcamp/dto/BootcampResponseDTO.java
@@ -21,6 +21,12 @@ public class BootcampResponseDTO {
     @Schema(description = "K-Digital Training 여부", example = "false")
     private Boolean isKdt;
 
+    @Schema(description = "부트캠프 시작일 (세션 기반 자동 갱신)", example = "2025-01-25")
+    private LocalDate startedAt;
+
+    @Schema(description = "부트캠프 종료일 (세션 기반 자동 갱신)", example = "2025-06-30")
+    private LocalDate endedAt;
+
     @Schema(description = "교육일 목록 (첫 날짜가 기준일이 되어 단위기간 자동 생성)",
         example = "[\"2025-01-25\", \"2025-01-26\", \"2025-01-27\"]")
     private List<LocalDate> classDates;

--- a/src/main/java/com/planit/planit/domain/bootcamp/mapper/BootcampMapper.java
+++ b/src/main/java/com/planit/planit/domain/bootcamp/mapper/BootcampMapper.java
@@ -1,5 +1,6 @@
 package com.planit.planit.domain.bootcamp.mapper;
 
+import java.time.LocalDate;
 import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
 import com.planit.planit.domain.bootcamp.dto.BootcampDTO;
@@ -13,6 +14,8 @@ public interface BootcampMapper {
   void insert(BootcampDTO bootcamp);
 
   void update(BootcampDTO bootcamp);
+
+  void updateDates(Long id, LocalDate startedAt, LocalDate endedAt);
 
   void delete(Long id);
 }

--- a/src/main/java/com/planit/planit/domain/bootcamp/service/BootcampService.java
+++ b/src/main/java/com/planit/planit/domain/bootcamp/service/BootcampService.java
@@ -41,7 +41,17 @@ public class BootcampService {
     if (bootcamp == null) {
       throw new BootcampNotFoundException("ID가 " + id + "인 부트캠프를 찾을 수 없습니다.");
     }
-    return toResponseDTO(bootcamp);
+    BootcampResponseDTO response = toResponseDTO(bootcamp);
+
+    // 단건 조회 시 세션에서 classDate를 추출하여 classDates에 채움
+    List<SessionDTO> sessions = sessionMapper.findByBootcampId(id);
+    if (sessions != null && !sessions.isEmpty()) {
+      List<LocalDate> classDates =
+          sessions.stream().map(SessionDTO::getClassDate).sorted().collect(Collectors.toList());
+      response.setClassDates(classDates);
+    }
+
+    return response;
   }
 
   @Transactional

--- a/src/main/java/com/planit/planit/domain/bootcamp/service/BootcampService.java
+++ b/src/main/java/com/planit/planit/domain/bootcamp/service/BootcampService.java
@@ -65,7 +65,12 @@ public class BootcampService {
     // 3. 교육일이 있으면 단위기간 및 세션 생성
     createUnitPeriodsAndSessions(bootcamp);
 
-    // 4. 저장된 데이터 조회 후 Response DTO로 반환
+    // 4. 세션 기반으로 부트캠프 시작일/종료일 갱신
+    if (bootcamp.getClassDates() != null && !bootcamp.getClassDates().isEmpty()) {
+      updateBootcampDates(bootcamp.getId());
+    }
+
+    // 5. 저장된 데이터 조회 후 Response DTO로 반환
     return getBootcamp(bootcamp.getId());
   }
 
@@ -196,6 +201,7 @@ public class BootcampService {
       SessionDTO session = new SessionDTO();
       session.setBootcampId(bootcampId);
       session.setPeriodId(period.getId());
+      session.setUnitNo(unitNo);
       session.setClassDate(classDate);
       sessions.add(session);
     }
@@ -218,13 +224,6 @@ public class BootcampService {
     // 부트캠프 수정 (업데이트 시간은 Mapper에서 NOW()로 자동 설정)
     bootcampMapper.update(bootcamp);
 
-    // 기존 세션 및 단위기간 삭제
-    sessionMapper.deleteByBootcampId(id);
-    unitPeriodMapper.deleteByBootcampId(id);
-
-    // 교육일이 있으면 단위기간 및 세션 재생성
-    createUnitPeriodsAndSessions(bootcamp);
-
     // 수정된 데이터 조회 후 Response DTO로 반환
     return getBootcamp(id);
   }
@@ -243,6 +242,42 @@ public class BootcampService {
     unitPeriodMapper.deleteByBootcampId(id);
     // 부트캠프 삭제
     bootcampMapper.delete(id);
+  }
+
+  /**
+   * 부트캠프의 시작일/종료일을 세션 기반으로 갱신합니다.
+   * 
+   * @param bootcampId 부트캠프 ID
+   */
+  @Transactional
+  public void updateBootcampDates(Long bootcampId) {
+    // 부트캠프 존재 확인
+    BootcampDTO bootcamp = bootcampMapper.findById(bootcampId);
+    if (bootcamp == null) {
+      throw new BootcampNotFoundException("ID가 " + bootcampId + "인 부트캠프를 찾을 수 없습니다.");
+    }
+
+    // 해당 부트캠프의 모든 세션 조회
+    List<SessionDTO> sessions = sessionMapper.findByBootcampId(bootcampId);
+
+    if (sessions == null || sessions.isEmpty()) {
+      // 세션이 없으면 시작일/종료일을 null로 설정
+      bootcampMapper.updateDates(bootcampId, null, null);
+    } else {
+      // 세션의 classDate 기준으로 최소/최대 날짜 계산
+      LocalDate startedAt = sessions.stream()
+          .map(SessionDTO::getClassDate)
+          .min(LocalDate::compareTo)
+          .orElse(null);
+
+      LocalDate endedAt = sessions.stream()
+          .map(SessionDTO::getClassDate)
+          .max(LocalDate::compareTo)
+          .orElse(null);
+
+      // 부트캠프의 시작일/종료일 갱신
+      bootcampMapper.updateDates(bootcampId, startedAt, endedAt);
+    }
   }
 
   /**
@@ -266,6 +301,8 @@ public class BootcampService {
     response.setName(dto.getName());
     response.setOrganizer(dto.getOrganizer());
     response.setIsKdt(dto.getIsKdt());
+    response.setStartedAt(dto.getStartedAt());
+    response.setEndedAt(dto.getEndedAt());
     response.setClassDates(dto.getClassDates());
     response.setCreatedAt(dto.getCreatedAt());
     response.setUpdatedAt(dto.getUpdatedAt());

--- a/src/main/java/com/planit/planit/domain/session/controller/SessionController.java
+++ b/src/main/java/com/planit/planit/domain/session/controller/SessionController.java
@@ -1,0 +1,197 @@
+package com.planit.planit.domain.session.controller;
+
+import java.util.List;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import com.planit.planit.domain.session.dto.SessionDTO;
+import com.planit.planit.domain.session.service.SessionService;
+import com.planit.planit.global.common.response.ApiResponse;
+import com.planit.planit.global.common.response.ErrorDetail;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+
+@RestController
+@RequestMapping("/api/v1/sessions")
+@Tag(name = "세션", description = "세션 관리 API")
+public class SessionController {
+
+  private final SessionService sessionService;
+
+  public SessionController(SessionService sessionService) {
+    this.sessionService = sessionService;
+  }
+
+  @Operation(summary = "세션 전체 목록 조회", description = "등록된 모든 세션 목록을 조회합니다.",
+      responses = {
+          @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200",
+              description = "조회 성공",
+              content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                  schema = @Schema(implementation = SessionListResponseSchema.class))),
+          @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500",
+              description = "서버 에러",
+              content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                  schema = @Schema(implementation = ApiErrorResponseSchema.class)))})
+  @GetMapping
+  public ResponseEntity<ApiResponse<List<SessionDTO>>> getAll() {
+    List<SessionDTO> sessions = sessionService.getAllSessions();
+    return ResponseEntity.ok(ApiResponse.success("세션 목록 조회 성공", sessions));
+  }
+
+  @Operation(summary = "부트캠프별 세션 목록 조회", description = "특정 부트캠프의 모든 세션 목록을 조회합니다.",
+      responses = {
+          @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200",
+              description = "조회 성공",
+              content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                  schema = @Schema(implementation = SessionListResponseSchema.class))),
+          @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404",
+              description = "부트캠프를 찾을 수 없음",
+              content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                  schema = @Schema(implementation = ApiErrorResponseSchema.class))),
+          @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500",
+              description = "서버 에러",
+              content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                  schema = @Schema(implementation = ApiErrorResponseSchema.class)))})
+  @GetMapping("/bootcamp/{bootcampId}")
+  public ResponseEntity<ApiResponse<List<SessionDTO>>> getByBootcampId(
+      @PathVariable Long bootcampId) {
+    List<SessionDTO> sessions = sessionService.getSessionsByBootcampId(bootcampId);
+    return ResponseEntity.ok(ApiResponse.success("부트캠프별 세션 목록 조회 성공", sessions));
+  }
+
+  @Operation(summary = "세션 단건 조회", description = "ID로 특정 세션을 조회합니다.",
+      responses = {
+          @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200",
+              description = "조회 성공",
+              content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                  schema = @Schema(implementation = SessionOneResponseSchema.class))),
+          @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404",
+              description = "세션을 찾을 수 없음",
+              content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                  schema = @Schema(implementation = ApiErrorResponseSchema.class))),
+          @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500",
+              description = "서버 에러",
+              content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                  schema = @Schema(implementation = ApiErrorResponseSchema.class)))})
+  @GetMapping("/{id}")
+  public ResponseEntity<ApiResponse<SessionDTO>> getOne(@PathVariable Long id) {
+    SessionDTO session = sessionService.getSession(id);
+    return ResponseEntity.ok(ApiResponse.success("세션 조회 성공", session));
+  }
+
+  @Operation(summary = "세션 등록", 
+      description = "새로운 세션을 등록합니다. "
+          + "**필수 필드**: bootcampId, unitNo, classDate. "
+          + "단위기간(unitNo)이 이미 존재하면 해당 단위기간을 사용하고, "
+          + "존재하지 않으면 periodStartDate와 periodEndDate를 제공해야 새로 생성됩니다.",
+      responses = {
+          @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201",
+              description = "등록 성공",
+              content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                  schema = @Schema(implementation = SessionOneResponseSchema.class))),
+          @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400",
+              description = "잘못된 요청",
+              content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                  schema = @Schema(implementation = ApiErrorResponseSchema.class))),
+          @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500",
+              description = "서버 에러",
+              content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                  schema = @Schema(implementation = ApiErrorResponseSchema.class)))})
+  @PostMapping
+  public ResponseEntity<ApiResponse<SessionDTO>> add(@Valid @RequestBody SessionDTO request) {
+    sessionService.addSession(request);
+    return ResponseEntity.status(HttpStatus.CREATED)
+        .body(ApiResponse.success("세션 등록 성공", request));
+  }
+
+  @Operation(summary = "세션 수정", 
+      description = "기존 세션 정보를 수정합니다. unitNo가 제공되면 해당 단위기간을 찾거나 생성합니다.",
+      responses = {
+          @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200",
+              description = "수정 성공",
+              content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                  schema = @Schema(implementation = SessionOneResponseSchema.class))),
+          @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404",
+              description = "세션을 찾을 수 없음",
+              content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                  schema = @Schema(implementation = ApiErrorResponseSchema.class))),
+          @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500",
+              description = "서버 에러",
+              content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                  schema = @Schema(implementation = ApiErrorResponseSchema.class)))})
+  @PutMapping("/{id}")
+  public ResponseEntity<ApiResponse<SessionDTO>> update(@PathVariable Long id,
+      @Valid @RequestBody SessionDTO request) {
+    request.setId(id);
+    sessionService.updateSession(request);
+    return ResponseEntity.ok(ApiResponse.success("세션 수정 성공", request));
+  }
+
+  @Operation(summary = "세션 삭제", description = "세션을 삭제합니다.",
+      responses = {
+          @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200",
+              description = "삭제 성공",
+              content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                  schema = @Schema(implementation = VoidResponseSchema.class))),
+          @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404",
+              description = "세션을 찾을 수 없음",
+              content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                  schema = @Schema(implementation = ApiErrorResponseSchema.class))),
+          @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500",
+              description = "서버 에러",
+              content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                  schema = @Schema(implementation = ApiErrorResponseSchema.class)))})
+  @DeleteMapping("/{id}")
+  public ResponseEntity<ApiResponse<Void>> delete(@PathVariable Long id) {
+    sessionService.deleteSession(id);
+    return ResponseEntity.ok(new ApiResponse<>(HttpStatus.OK.value(), "세션 삭제 성공", null));
+  }
+
+  @Schema(name = "SessionListResponse", description = "세션 목록 응답")
+  static class SessionListResponseSchema {
+    @Schema(example = "200")
+    public int code;
+    @Schema(example = "세션 목록 조회 성공")
+    public String message;
+    public List<SessionDTO> data;
+  }
+
+  @Schema(name = "SessionOneResponse", description = "세션 단건 응답")
+  static class SessionOneResponseSchema {
+    @Schema(example = "200")
+    public int code;
+    @Schema(example = "세션 조회 성공")
+    public String message;
+    public SessionDTO data;
+  }
+
+  @Schema(name = "VoidResponse", description = "데이터 없는 성공 응답")
+  static class VoidResponseSchema {
+    @Schema(example = "200")
+    public int code;
+    @Schema(example = "세션 삭제 성공")
+    public String message;
+    public Void data;
+  }
+
+  @Schema(name = "ApiErrorResponse", description = "실패 응답(에러)")
+  static class ApiErrorResponseSchema {
+    @Schema(example = "400")
+    public int code;
+    @Schema(example = "잘못된 [인자]입니다.")
+    public String message;
+    public List<ErrorDetail> errors;
+  }
+}
+

--- a/src/main/java/com/planit/planit/domain/session/dto/SessionDTO.java
+++ b/src/main/java/com/planit/planit/domain/session/dto/SessionDTO.java
@@ -11,15 +11,23 @@ public class SessionDTO {
   @Schema(description = "세션 ID", example = "1")
   private Long id;
 
-  @Schema(description = "부트캠프 ID", example = "1")
+  @Schema(description = "부트캠프 ID", example = "1", required = true)
   @NotNull(message = "부트캠프 ID는 필수입니다")
   private Long bootcampId;
 
-  @Schema(description = "단위기간 ID", example = "1")
-  @NotNull(message = "단위기간 ID는 필수입니다")
+  @Schema(description = "단위기간 ID (자동 설정됨)", example = "1")
   private Long periodId;
 
-  @Schema(description = "수업 날짜", example = "2025-01-15")
+  @Schema(description = "단위기간 번호 (세션 등록 시 필수)", example = "1", required = true)
+  private Integer unitNo;
+
+  @Schema(description = "단위기간 시작일 (신규 단위기간 생성 시 필수)", example = "2025-01-01")
+  private LocalDate periodStartDate;
+
+  @Schema(description = "단위기간 종료일 (신규 단위기간 생성 시 필수)", example = "2025-01-31")
+  private LocalDate periodEndDate;
+
+  @Schema(description = "수업 날짜", example = "2025-01-15", required = true)
   @NotNull(message = "수업 날짜는 필수입니다")
   private LocalDate classDate;
 

--- a/src/main/java/com/planit/planit/domain/session/exception/SessionUnitNoRequiredException.java
+++ b/src/main/java/com/planit/planit/domain/session/exception/SessionUnitNoRequiredException.java
@@ -1,0 +1,16 @@
+package com.planit.planit.domain.session.exception;
+
+import com.planit.planit.global.common.exception.BaseException;
+import com.planit.planit.global.common.exception.ErrorCode;
+
+public class SessionUnitNoRequiredException extends BaseException {
+
+  public SessionUnitNoRequiredException() {
+    super(ErrorCode.SESSION_UNIT_NO_REQUIRED);
+  }
+
+  public SessionUnitNoRequiredException(String message) {
+    super(ErrorCode.SESSION_UNIT_NO_REQUIRED, message);
+  }
+}
+

--- a/src/main/java/com/planit/planit/domain/session/service/SessionService.java
+++ b/src/main/java/com/planit/planit/domain/session/service/SessionService.java
@@ -6,6 +6,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.planit.planit.domain.bootcamp.service.BootcampService;
 import com.planit.planit.domain.session.dto.SessionDTO;
 import com.planit.planit.domain.session.exception.SessionNotFoundException;
+import com.planit.planit.domain.session.exception.SessionUnitNoRequiredException;
 import com.planit.planit.domain.session.mapper.SessionMapper;
 import com.planit.planit.domain.unitperiod.dto.UnitPeriodDTO;
 import com.planit.planit.domain.unitperiod.service.UnitPeriodService;
@@ -48,7 +49,7 @@ public class SessionService {
 
     // 단위기간 정보 검증
     if (session.getUnitNo() == null) {
-      throw new IllegalArgumentException("단위기간 번호(unitNo)는 필수입니다.");
+      throw new SessionUnitNoRequiredException("단위기간 번호(unitNo)는 필수입니다.");
     }
 
     // 단위기간 찾거나 생성

--- a/src/main/java/com/planit/planit/domain/session/service/SessionService.java
+++ b/src/main/java/com/planit/planit/domain/session/service/SessionService.java
@@ -7,15 +7,20 @@ import com.planit.planit.domain.bootcamp.service.BootcampService;
 import com.planit.planit.domain.session.dto.SessionDTO;
 import com.planit.planit.domain.session.exception.SessionNotFoundException;
 import com.planit.planit.domain.session.mapper.SessionMapper;
+import com.planit.planit.domain.unitperiod.dto.UnitPeriodDTO;
+import com.planit.planit.domain.unitperiod.service.UnitPeriodService;
 
 @Service
 public class SessionService {
   private final SessionMapper sessionMapper;
   private final BootcampService bootcampService;
+  private final UnitPeriodService unitPeriodService;
 
-  public SessionService(SessionMapper sessionMapper, BootcampService bootcampService) {
+  public SessionService(SessionMapper sessionMapper, BootcampService bootcampService,
+      UnitPeriodService unitPeriodService) {
     this.sessionMapper = sessionMapper;
     this.bootcampService = bootcampService;
+    this.unitPeriodService = unitPeriodService;
   }
 
   public List<SessionDTO> getAllSessions() {
@@ -40,7 +45,26 @@ public class SessionService {
   public void addSession(SessionDTO session) {
     // 부트캠프 존재 여부 검증 (존재하지 않으면 BootcampNotFoundException 발생)
     bootcampService.getBootcamp(session.getBootcampId());
+
+    // 단위기간 정보 검증
+    if (session.getUnitNo() == null) {
+      throw new IllegalArgumentException("단위기간 번호(unitNo)는 필수입니다.");
+    }
+
+    // 단위기간 찾거나 생성
+    UnitPeriodDTO unitPeriod = new UnitPeriodDTO();
+    unitPeriod.setBootcampId(session.getBootcampId());
+    unitPeriod.setUnitNo(session.getUnitNo());
+    unitPeriod.setStartDate(session.getPeriodStartDate());
+    unitPeriod.setEndDate(session.getPeriodEndDate());
+
+    Long periodId = unitPeriodService.findOrCreateUnitPeriod(unitPeriod);
+    session.setPeriodId(periodId);
+
     sessionMapper.insert(session);
+
+    // 부트캠프의 시작일/종료일 갱신
+    bootcampService.updateBootcampDates(session.getBootcampId());
   }
 
   @Transactional
@@ -51,7 +75,23 @@ public class SessionService {
     }
     // 부트캠프 존재 여부 검증 (존재하지 않으면 BootcampNotFoundException 발생)
     bootcampService.getBootcamp(session.getBootcampId());
+
+    // 단위기간 찾거나 생성 (unitNo가 제공된 경우)
+    if (session.getUnitNo() != null) {
+      UnitPeriodDTO unitPeriod = new UnitPeriodDTO();
+      unitPeriod.setBootcampId(session.getBootcampId());
+      unitPeriod.setUnitNo(session.getUnitNo());
+      unitPeriod.setStartDate(session.getPeriodStartDate());
+      unitPeriod.setEndDate(session.getPeriodEndDate());
+
+      Long periodId = unitPeriodService.findOrCreateUnitPeriod(unitPeriod);
+      session.setPeriodId(periodId);
+    }
+
     sessionMapper.update(session);
+
+    // 부트캠프의 시작일/종료일 갱신 (classDate가 변경될 수 있으므로)
+    bootcampService.updateBootcampDates(session.getBootcampId());
   }
 
   @Transactional
@@ -60,6 +100,11 @@ public class SessionService {
     if (existingSession == null) {
       throw new SessionNotFoundException("ID가 " + id + "인 세션을 찾을 수 없습니다.");
     }
+    
+    Long bootcampId = existingSession.getBootcampId();
     sessionMapper.delete(id);
+
+    // 부트캠프의 시작일/종료일 갱신
+    bootcampService.updateBootcampDates(bootcampId);
   }
 }

--- a/src/main/java/com/planit/planit/domain/unitperiod/exception/UnitPeriodDatesRequiredException.java
+++ b/src/main/java/com/planit/planit/domain/unitperiod/exception/UnitPeriodDatesRequiredException.java
@@ -1,0 +1,16 @@
+package com.planit.planit.domain.unitperiod.exception;
+
+import com.planit.planit.global.common.exception.BaseException;
+import com.planit.planit.global.common.exception.ErrorCode;
+
+public class UnitPeriodDatesRequiredException extends BaseException {
+
+  public UnitPeriodDatesRequiredException() {
+    super(ErrorCode.UNIT_PERIOD_DATES_REQUIRED);
+  }
+
+  public UnitPeriodDatesRequiredException(String message) {
+    super(ErrorCode.UNIT_PERIOD_DATES_REQUIRED, message);
+  }
+}
+

--- a/src/main/java/com/planit/planit/domain/unitperiod/mapper/UnitPeriodMapper.java
+++ b/src/main/java/com/planit/planit/domain/unitperiod/mapper/UnitPeriodMapper.java
@@ -12,6 +12,8 @@ public interface UnitPeriodMapper {
 
   UnitPeriodDTO findById(Long id);
 
+  UnitPeriodDTO findByBootcampIdAndUnitNo(Long bootcampId, Integer unitNo);
+
   void insert(UnitPeriodDTO unitPeriod);
 
   void update(UnitPeriodDTO unitPeriod);

--- a/src/main/java/com/planit/planit/domain/unitperiod/service/UnitPeriodService.java
+++ b/src/main/java/com/planit/planit/domain/unitperiod/service/UnitPeriodService.java
@@ -43,6 +43,36 @@ public class UnitPeriodService {
     unitPeriodMapper.insert(unitPeriod);
   }
 
+  /**
+   * 단위기간을 찾거나 생성합니다.
+   * 
+   * @param unitPeriod 단위기간 정보 (bootcampId, unitNo 필수, startDate/endDate 선택)
+   * @return 생성되거나 찾은 단위기간의 ID
+   */
+  @Transactional
+  public Long findOrCreateUnitPeriod(UnitPeriodDTO unitPeriod) {
+    // 부트캠프 존재 여부 검증
+    bootcampService.getBootcamp(unitPeriod.getBootcampId());
+
+    // 기존 단위기간 조회
+    UnitPeriodDTO existingPeriod =
+        unitPeriodMapper.findByBootcampIdAndUnitNo(unitPeriod.getBootcampId(), unitPeriod.getUnitNo());
+
+    if (existingPeriod != null) {
+      // 기존 단위기간이 있으면 해당 ID 반환
+      return existingPeriod.getId();
+    } else {
+      // 없으면 새로 생성
+      // startDate와 endDate가 제공되지 않으면 오류
+      if (unitPeriod.getStartDate() == null || unitPeriod.getEndDate() == null) {
+        throw new IllegalArgumentException(
+            "새로운 단위기간을 생성하려면 시작일(periodStartDate)과 종료일(periodEndDate)이 필요합니다.");
+      }
+      unitPeriodMapper.insert(unitPeriod);
+      return unitPeriod.getId();
+    }
+  }
+
   @Transactional
   public void updateUnitPeriod(UnitPeriodDTO unitPeriod) {
     UnitPeriodDTO existingUnitPeriod = unitPeriodMapper.findById(unitPeriod.getId());

--- a/src/main/java/com/planit/planit/domain/unitperiod/service/UnitPeriodService.java
+++ b/src/main/java/com/planit/planit/domain/unitperiod/service/UnitPeriodService.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import com.planit.planit.domain.bootcamp.service.BootcampService;
 import com.planit.planit.domain.unitperiod.dto.UnitPeriodDTO;
+import com.planit.planit.domain.unitperiod.exception.UnitPeriodDatesRequiredException;
 import com.planit.planit.domain.unitperiod.exception.UnitPeriodNotFoundException;
 import com.planit.planit.domain.unitperiod.mapper.UnitPeriodMapper;
 
@@ -65,7 +66,7 @@ public class UnitPeriodService {
       // 없으면 새로 생성
       // startDate와 endDate가 제공되지 않으면 오류
       if (unitPeriod.getStartDate() == null || unitPeriod.getEndDate() == null) {
-        throw new IllegalArgumentException(
+        throw new UnitPeriodDatesRequiredException(
             "새로운 단위기간을 생성하려면 시작일(periodStartDate)과 종료일(periodEndDate)이 필요합니다.");
       }
       unitPeriodMapper.insert(unitPeriod);

--- a/src/main/java/com/planit/planit/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/planit/planit/global/common/exception/ErrorCode.java
@@ -32,9 +32,11 @@ public enum ErrorCode {
 
     // Session Errors
     SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "세션을 찾을 수 없습니다."),
+    SESSION_UNIT_NO_REQUIRED(HttpStatus.BAD_REQUEST, "단위기간 번호는 필수입니다."),
 
     // UnitPeriod Errors
-    UNIT_PERIOD_NOT_FOUND(HttpStatus.NOT_FOUND, "단위기간을 찾을 수 없습니다.");
+    UNIT_PERIOD_NOT_FOUND(HttpStatus.NOT_FOUND, "단위기간을 찾을 수 없습니다."),
+    UNIT_PERIOD_DATES_REQUIRED(HttpStatus.BAD_REQUEST, "새로운 단위기간을 생성하려면 시작일과 종료일이 필요합니다.");
 
     private final HttpStatus status;
 

--- a/src/main/resources/mapper/BootcampMapper.xml
+++ b/src/main/resources/mapper/BootcampMapper.xml
@@ -7,14 +7,16 @@
 
   <!-- 전체 조회 -->
   <select id="findAll" resultType="com.planit.planit.domain.bootcamp.dto.BootcampDTO">
-    SELECT id, name, organizer, is_kdt as "isKdt", created_at as "createdAt", updated_at as "updatedAt"
+    SELECT id, name, organizer, is_kdt as "isKdt", started_at as "startedAt", ended_at as "endedAt",
+           created_at as "createdAt", updated_at as "updatedAt"
     FROM bootcamps
     ORDER BY created_at DESC
   </select>
 
   <!-- 단일 조회 -->
   <select id="findById" parameterType="long" resultType="com.planit.planit.domain.bootcamp.dto.BootcampDTO">
-    SELECT id, name, organizer, is_kdt as "isKdt", created_at as "createdAt", updated_at as "updatedAt"
+    SELECT id, name, organizer, is_kdt as "isKdt", started_at as "startedAt", ended_at as "endedAt",
+           created_at as "createdAt", updated_at as "updatedAt"
     FROM bootcamps
     WHERE id = #{id}
   </select>
@@ -29,9 +31,18 @@
   <update id="update" parameterType="com.planit.planit.domain.bootcamp.dto.BootcampDTO">
     UPDATE bootcamps
     SET name = #{name},
-        organizer = #{organizer}
-      is_kdt = #{isKdt},
-      updated_at = NOW()
+        organizer = #{organizer},
+        is_kdt = #{isKdt},
+        updated_at = NOW()
+    WHERE id = #{id}
+  </update>
+
+  <!-- 시작일/종료일 갱신 -->
+  <update id="updateDates">
+    UPDATE bootcamps
+    SET started_at = #{startedAt},
+        ended_at = #{endedAt},
+        updated_at = NOW()
     WHERE id = #{id}
   </update>
 

--- a/src/main/resources/mapper/SessionMapper.xml
+++ b/src/main/resources/mapper/SessionMapper.xml
@@ -7,27 +7,39 @@
 
     <!-- 전체 조회 -->
     <select id="findAll" resultType="com.planit.planit.domain.session.dto.SessionDTO">
-        SELECT id, bootcamp_id as "bootcampId", period_id as "periodId", 
-               class_date as "classDate", created_at as "createdAt", updated_at as "updatedAt"
-        FROM sessions
-        ORDER BY class_date ASC
+        SELECT s.id, s.bootcamp_id as "bootcampId", s.period_id as "periodId",
+               up.unit_no as "unitNo",
+               up.start_date as "periodStartDate",
+               up.end_date as "periodEndDate",
+               s.class_date as "classDate", s.created_at as "createdAt", s.updated_at as "updatedAt"
+        FROM sessions s
+        LEFT JOIN unit_periods up ON s.period_id = up.id
+        ORDER BY s.class_date ASC
     </select>
 
     <!-- 부트캠프별 조회 -->
     <select id="findByBootcampId" parameterType="long" resultType="com.planit.planit.domain.session.dto.SessionDTO">
-        SELECT id, bootcamp_id as "bootcampId", period_id as "periodId", 
-               class_date as "classDate", created_at as "createdAt", updated_at as "updatedAt"
-        FROM sessions
-        WHERE bootcamp_id = #{bootcampId}
-        ORDER BY class_date ASC
+        SELECT s.id, s.bootcamp_id as "bootcampId", s.period_id as "periodId",
+               up.unit_no as "unitNo",
+               up.start_date as "periodStartDate",
+               up.end_date as "periodEndDate",
+               s.class_date as "classDate", s.created_at as "createdAt", s.updated_at as "updatedAt"
+        FROM sessions s
+        LEFT JOIN unit_periods up ON s.period_id = up.id
+        WHERE s.bootcamp_id = #{bootcampId}
+        ORDER BY s.class_date ASC
     </select>
 
     <!-- 단일 조회 -->
     <select id="findById" parameterType="long" resultType="com.planit.planit.domain.session.dto.SessionDTO">
-        SELECT id, bootcamp_id as "bootcampId", period_id as "periodId", 
-               class_date as "classDate", created_at as "createdAt", updated_at as "updatedAt"
-        FROM sessions
-        WHERE id = #{id}
+        SELECT s.id, s.bootcamp_id as "bootcampId", s.period_id as "periodId",
+               up.unit_no as "unitNo",
+               up.start_date as "periodStartDate",
+               up.end_date as "periodEndDate",
+               s.class_date as "classDate", s.created_at as "createdAt", s.updated_at as "updatedAt"
+        FROM sessions s
+        LEFT JOIN unit_periods up ON s.period_id = up.id
+        WHERE s.id = #{id}
     </select>
 
     <!-- 단일 추가 -->

--- a/src/main/resources/mapper/UnitPeriodMapper.xml
+++ b/src/main/resources/mapper/UnitPeriodMapper.xml
@@ -30,6 +30,14 @@
         WHERE id = #{id}
     </select>
 
+    <!-- 부트캠프ID와 단위번호로 조회 -->
+    <select id="findByBootcampIdAndUnitNo" resultType="com.planit.planit.domain.unitperiod.dto.UnitPeriodDTO">
+        SELECT id, bootcamp_id as "bootcampId", unit_no as "unitNo", 
+               start_date as "startDate", end_date as "endDate", created_at as "createdAt"
+        FROM unit_periods
+        WHERE bootcamp_id = #{bootcampId} AND unit_no = #{unitNo}
+    </select>
+
     <!-- 추가 -->
     <insert id="insert" parameterType="com.planit.planit.domain.unitperiod.dto.UnitPeriodDTO" useGeneratedKeys="true" keyProperty="id">
         INSERT INTO unit_periods (bootcamp_id, unit_no, start_date, end_date, created_at)


### PR DESCRIPTION
## ✨ 이 PR의 목적
- 세부적인 시간표 관리 기능의 부재

## 📄 작업 내용 요약
- 시간표 조회, 추가, 삭제 추가
- 시간표 추가, 삭제 시 부트캠프의 시작일과 종료일 갱신
- 시간표 추가 시 단위기간이 필요하다면 자동 생성, 중복 생성 방지
- 일관적인 예외 형태

## 📎 Issue 번호
- Close: #18 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **New Features**
  * 세션 관리 API 추가: 전체 조회, 부트캠프별 조회, 개별 조회, 생성, 수정, 삭제 엔드포인트 제공
  * 부트캠프 시작/종료 날짜 필드 추가
  * 세션 정보에 단위기간 번호 및 기간 날짜 데이터 포함

* **Improvements**
  * 세션 및 단위기간 생성 시 필수 필드 검증 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->