### PR TITLE
[FIX] 시간표 추가, 제거 수정

### DIFF
--- a/src/main/java/com/planit/planit/domain/session/controller/SessionController.java
+++ b/src/main/java/com/planit/planit/domain/session/controller/SessionController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import com.planit.planit.domain.session.dto.SessionCreateRequestDTO;
+import com.planit.planit.domain.session.dto.SessionDeleteRequestDTO;
 import com.planit.planit.domain.session.dto.SessionDTO;
 import com.planit.planit.domain.session.service.SessionService;
 import com.planit.planit.global.common.response.ApiResponse;
@@ -91,15 +92,15 @@ public class SessionController {
   }
 
 	@Operation(summary = "세션 등록", 
-		description = "새로운 세션을 등록합니다. "
-			+ "**필수 필드**: bootcampId, classDate. "
+		description = "여러 세션을 한번에 등록합니다. "
+			+ "**필수 필드**: bootcampId, sessions[].classDate. "
 			+ "unitNo, periodStartDate, periodEndDate는 자동으로 계산됩니다. "
 			+ "단위기간이 존재하지 않으면 자동으로 생성됩니다.",
 		responses = {
           @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201",
               description = "등록 성공",
               content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
-                  schema = @Schema(implementation = SessionOneResponseSchema.class))),
+                  schema = @Schema(implementation = SessionListResponseSchema.class))),
           @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400",
               description = "잘못된 요청",
               content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
@@ -109,14 +110,15 @@ public class SessionController {
               content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
                   schema = @Schema(implementation = ApiErrorResponseSchema.class)))})
   @PostMapping
-  public ResponseEntity<ApiResponse<SessionDTO>> add(@Valid @RequestBody SessionCreateRequestDTO request) {
-    SessionDTO createdSession = sessionService.addSession(request);
+  public ResponseEntity<ApiResponse<List<SessionDTO>>> add(@Valid @RequestBody SessionCreateRequestDTO request) {
+    List<SessionDTO> createdSessions = sessionService.addSession(request);
     return ResponseEntity.status(HttpStatus.CREATED)
-        .body(ApiResponse.success("세션 등록 성공", createdSession));
+        .body(ApiResponse.success("세션 등록 성공", createdSessions));
   }
 
+
   @Operation(summary = "세션 삭제", 
-      description = "세션을 삭제합니다. 단, 부트캠프의 시작일에 해당하는 세션은 삭제할 수 없습니다.",
+      description = "여러 세션을 한번에 삭제합니다. 단, 부트캠프의 시작일에 해당하는 세션은 삭제할 수 없습니다.",
       responses = {
           @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200",
               description = "삭제 성공",
@@ -134,9 +136,9 @@ public class SessionController {
               description = "서버 에러",
               content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
                   schema = @Schema(implementation = ApiErrorResponseSchema.class)))})
-  @DeleteMapping("/{id}")
-  public ResponseEntity<ApiResponse<Void>> delete(@PathVariable Long id) {
-    sessionService.deleteSession(id);
+  @DeleteMapping
+  public ResponseEntity<ApiResponse<Void>> delete(@Valid @RequestBody SessionDeleteRequestDTO request) {
+    sessionService.deleteSessions(request);
     return ResponseEntity.ok(new ApiResponse<>(HttpStatus.OK.value(), "세션 삭제 성공", null));
   }
 

--- a/src/main/java/com/planit/planit/domain/session/dto/SessionCreateItemDTO.java
+++ b/src/main/java/com/planit/planit/domain/session/dto/SessionCreateItemDTO.java
@@ -1,0 +1,14 @@
+package com.planit.planit.domain.session.dto;
+
+import java.time.LocalDate;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+@Data
+@Schema(description = "세션 등록 아이템 DTO")
+public class SessionCreateItemDTO {
+  @Schema(description = "수업 날짜", example = "2025-01-15", required = true)
+  @NotNull(message = "수업 날짜는 필수입니다")
+  private LocalDate classDate;
+}

--- a/src/main/java/com/planit/planit/domain/session/dto/SessionCreateRequestDTO.java
+++ b/src/main/java/com/planit/planit/domain/session/dto/SessionCreateRequestDTO.java
@@ -1,7 +1,9 @@
 package com.planit.planit.domain.session.dto;
 
-import java.time.LocalDate;
+import java.util.List;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 
@@ -12,8 +14,9 @@ public class SessionCreateRequestDTO {
   @NotNull(message = "부트캠프 ID는 필수입니다")
   private Long bootcampId;
 
-  @Schema(description = "수업 날짜", example = "2025-01-15", required = true)
-  @NotNull(message = "수업 날짜는 필수입니다")
-  private LocalDate classDate;
+  @Schema(description = "세션 목록", example = "[{\"classDate\": \"2025-01-15\"}, {\"classDate\": \"2025-01-16\"}]", required = true)
+  @NotEmpty(message = "세션 목록은 비어있을 수 없습니다")
+  @Valid
+  private List<SessionCreateItemDTO> sessions;
 }
 

--- a/src/main/java/com/planit/planit/domain/session/dto/SessionDeleteRequestDTO.java
+++ b/src/main/java/com/planit/planit/domain/session/dto/SessionDeleteRequestDTO.java
@@ -1,0 +1,14 @@
+package com.planit.planit.domain.session.dto;
+
+import java.util.List;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Data;
+
+@Data
+@Schema(description = "세션 삭제 요청 DTO")
+public class SessionDeleteRequestDTO {
+  @Schema(description = "삭제할 세션 ID 목록", example = "[1, 2, 3]", required = true)
+  @NotEmpty(message = "삭제할 세션 ID 목록은 비어있을 수 없습니다")
+  private List<Long> sessionIds;
+}

--- a/src/main/java/com/planit/planit/domain/session/exception/SessionDifferentBootcampException.java
+++ b/src/main/java/com/planit/planit/domain/session/exception/SessionDifferentBootcampException.java
@@ -1,0 +1,15 @@
+package com.planit.planit.domain.session.exception;
+
+import com.planit.planit.global.common.exception.BaseException;
+import com.planit.planit.global.common.exception.ErrorCode;
+
+public class SessionDifferentBootcampException extends BaseException {
+
+    public SessionDifferentBootcampException() {
+        super(ErrorCode.SESSION_DIFFERENT_BOOTCAMP);
+    }
+
+    public SessionDifferentBootcampException(String message) {
+        super(ErrorCode.SESSION_DIFFERENT_BOOTCAMP, message);
+    }
+}

--- a/src/main/java/com/planit/planit/domain/session/exception/SessionDuplicateDateException.java
+++ b/src/main/java/com/planit/planit/domain/session/exception/SessionDuplicateDateException.java
@@ -1,0 +1,15 @@
+package com.planit.planit.domain.session.exception;
+
+import com.planit.planit.global.common.exception.BaseException;
+import com.planit.planit.global.common.exception.ErrorCode;
+
+public class SessionDuplicateDateException extends BaseException {
+
+    public SessionDuplicateDateException() {
+        super(ErrorCode.SESSION_DUPLICATE_DATE);
+    }
+
+    public SessionDuplicateDateException(String message) {
+        super(ErrorCode.SESSION_DUPLICATE_DATE, message);
+    }
+}

--- a/src/main/java/com/planit/planit/domain/session/exception/SessionEmptyCreateListException.java
+++ b/src/main/java/com/planit/planit/domain/session/exception/SessionEmptyCreateListException.java
@@ -1,0 +1,15 @@
+package com.planit.planit.domain.session.exception;
+
+import com.planit.planit.global.common.exception.BaseException;
+import com.planit.planit.global.common.exception.ErrorCode;
+
+public class SessionEmptyCreateListException extends BaseException {
+
+    public SessionEmptyCreateListException() {
+        super(ErrorCode.SESSION_EMPTY_CREATE_LIST);
+    }
+
+    public SessionEmptyCreateListException(String message) {
+        super(ErrorCode.SESSION_EMPTY_CREATE_LIST, message);
+    }
+}

--- a/src/main/java/com/planit/planit/domain/session/exception/SessionEmptyDeleteListException.java
+++ b/src/main/java/com/planit/planit/domain/session/exception/SessionEmptyDeleteListException.java
@@ -1,0 +1,15 @@
+package com.planit.planit.domain.session.exception;
+
+import com.planit.planit.global.common.exception.BaseException;
+import com.planit.planit.global.common.exception.ErrorCode;
+
+public class SessionEmptyDeleteListException extends BaseException {
+
+    public SessionEmptyDeleteListException() {
+        super(ErrorCode.SESSION_EMPTY_DELETE_LIST);
+    }
+
+    public SessionEmptyDeleteListException(String message) {
+        super(ErrorCode.SESSION_EMPTY_DELETE_LIST, message);
+    }
+}

--- a/src/main/java/com/planit/planit/domain/session/exception/SessionNullClassDateException.java
+++ b/src/main/java/com/planit/planit/domain/session/exception/SessionNullClassDateException.java
@@ -1,0 +1,15 @@
+package com.planit.planit.domain.session.exception;
+
+import com.planit.planit.global.common.exception.BaseException;
+import com.planit.planit.global.common.exception.ErrorCode;
+
+public class SessionNullClassDateException extends BaseException {
+
+    public SessionNullClassDateException() {
+        super(ErrorCode.SESSION_NULL_CLASS_DATE);
+    }
+
+    public SessionNullClassDateException(String message) {
+        super(ErrorCode.SESSION_NULL_CLASS_DATE, message);
+    }
+}

--- a/src/main/java/com/planit/planit/domain/session/service/SessionService.java
+++ b/src/main/java/com/planit/planit/domain/session/service/SessionService.java
@@ -88,18 +88,9 @@ public class SessionService {
 			throw new SessionDuplicateDateException("요청 내에 중복된 날짜가 있습니다.");
 		}
 
-		// 기존 세션과의 중복 날짜 검증
-		List<SessionDTO> existingSessions = sessionMapper.findByBootcampId(request.getBootcampId());
-		Set<LocalDate> existingDates = existingSessions.stream()
-			.map(SessionDTO::getClassDate)
-			.collect(java.util.stream.Collectors.toSet());
-
-		for (LocalDate requestDate : requestDates) {
-			if (existingDates.contains(requestDate)) {
-				throw new SessionDuplicateDateException(
-					"날짜 " + requestDate + "에 해당하는 세션이 이미 존재합니다.");
-			}
-		}
+		// DB 유니크 제약에 의존 (동시성 문제 해결)
+		// 메모리 내 중복 검사는 TOCTOU 문제로 인해 제거
+		// DB 레벨에서 (bootcamp_id, class_date) 유니크 제약으로 보장
 
 		// 기준일 결정: startedAt이 설정되어 있으면 사용, 없으면 세션들 중 가장 이른 날짜를 기준으로 함
 		LocalDate baseDate = (bootcamp.getStartedAt() != null) 

--- a/src/main/java/com/planit/planit/domain/session/service/SessionService.java
+++ b/src/main/java/com/planit/planit/domain/session/service/SessionService.java
@@ -100,7 +100,7 @@ public class SessionService {
 		
 		int baseDay = unitPeriodCalculator.getBaseDay(baseDate);
 
-		List<SessionDTO> createdSessions = new java.util.ArrayList<>();
+		List<SessionDTO> sessionsToInsert = new java.util.ArrayList<>();
 
 		for (SessionCreateItemDTO sessionItem : request.getSessions()) {
 			// 부트캠프 시작일 이후인지 검증 (엄격한 검증)
@@ -131,16 +131,17 @@ public class SessionService {
 			Long periodId = unitPeriodService.findOrCreateUnitPeriod(unitPeriod);
 			session.setPeriodId(periodId);
 
-			sessionMapper.insert(session);
-
-			// 생성된 세션을 리스트에 추가 (재조회 불필요)
-			createdSessions.add(session);
+			sessionsToInsert.add(session);
 		}
+
+		// 배치 insert 실행 (ID 자동 할당)
+		sessionMapper.insertBatch(sessionsToInsert);
 
 		// 부트캠프의 시작일/종료일 갱신
 		bootcampService.updateBootcampDates(request.getBootcampId());
 
-		return createdSessions;
+		// 생성된 세션들 반환 (ID가 자동으로 할당됨)
+		return sessionsToInsert;
 	}
 
 

--- a/src/main/java/com/planit/planit/global/common/advice/GlobalExceptionHandler.java
+++ b/src/main/java/com/planit/planit/global/common/advice/GlobalExceptionHandler.java
@@ -170,6 +170,15 @@ public class GlobalExceptionHandler {
 	/** 409 - DB/유니크 제약 위반 등 */
 	@ExceptionHandler({DataIntegrityViolationException.class, DuplicateKeyException.class})
 	public ResponseEntity<ApiErrorResponse<ErrorDetail>> handleConflict(Exception e) {
+		// 세션 중복 날짜 특화 처리
+		if (e.getMessage() != null && e.getMessage().contains("sessions") && 
+			(e.getMessage().contains("bootcamp_id") || e.getMessage().contains("class_date"))) {
+			String msg = SESSION_DUPLICATE_DATE.getMessage();
+			logWarn(e, SESSION_DUPLICATE_DATE.getStatus().value(), msg);
+			return ResponseEntity.status(SESSION_DUPLICATE_DATE.getStatus())
+				.body(ApiErrorResponse.of(SESSION_DUPLICATE_DATE.getStatus(), msg));
+		}
+		
 		String msg = CONFLICT.getMessage();
 		logWarn(e, CONFLICT.getStatus().value(), msg);
 		return ResponseEntity.status(CONFLICT.getStatus())

--- a/src/main/java/com/planit/planit/global/common/advice/GlobalExceptionHandler.java
+++ b/src/main/java/com/planit/planit/global/common/advice/GlobalExceptionHandler.java
@@ -170,15 +170,6 @@ public class GlobalExceptionHandler {
 	/** 409 - DB/유니크 제약 위반 등 */
 	@ExceptionHandler({DataIntegrityViolationException.class, DuplicateKeyException.class})
 	public ResponseEntity<ApiErrorResponse<ErrorDetail>> handleConflict(Exception e) {
-		// 세션 중복 날짜 특화 처리
-		if (e.getMessage() != null && e.getMessage().contains("sessions") && 
-			(e.getMessage().contains("bootcamp_id") || e.getMessage().contains("class_date"))) {
-			String msg = SESSION_DUPLICATE_DATE.getMessage();
-			logWarn(e, SESSION_DUPLICATE_DATE.getStatus().value(), msg);
-			return ResponseEntity.status(SESSION_DUPLICATE_DATE.getStatus())
-				.body(ApiErrorResponse.of(SESSION_DUPLICATE_DATE.getStatus(), msg));
-		}
-		
 		String msg = CONFLICT.getMessage();
 		logWarn(e, CONFLICT.getStatus().value(), msg);
 		return ResponseEntity.status(CONFLICT.getStatus())

--- a/src/main/java/com/planit/planit/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/planit/planit/global/common/exception/ErrorCode.java
@@ -38,6 +38,7 @@ public enum ErrorCode {
 	SESSION_IS_BOOTCAMP_START_DATE(HttpStatus.BAD_REQUEST, "부트캠프 시작일에 해당하는 세션은 삭제할 수 없습니다."),
 	SESSION_EMPTY_DELETE_LIST(HttpStatus.BAD_REQUEST, "삭제할 세션이 없습니다."),
 	SESSION_DIFFERENT_BOOTCAMP(HttpStatus.BAD_REQUEST, "서로 다른 부트캠프의 세션들을 함께 삭제할 수 없습니다."),
+	SESSION_DUPLICATE_DATE(HttpStatus.CONFLICT, "동일한 날짜의 세션이 이미 존재합니다."),
 
 	// UnitPeriod Errors
 	UNIT_PERIOD_NOT_FOUND(HttpStatus.NOT_FOUND, "단위기간을 찾을 수 없습니다."),

--- a/src/main/java/com/planit/planit/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/planit/planit/global/common/exception/ErrorCode.java
@@ -39,6 +39,7 @@ public enum ErrorCode {
 	SESSION_EMPTY_DELETE_LIST(HttpStatus.BAD_REQUEST, "삭제할 세션이 없습니다."),
 	SESSION_DIFFERENT_BOOTCAMP(HttpStatus.BAD_REQUEST, "서로 다른 부트캠프의 세션들을 함께 삭제할 수 없습니다."),
 	SESSION_DUPLICATE_DATE(HttpStatus.CONFLICT, "동일한 날짜의 세션이 이미 존재합니다."),
+	SESSION_EMPTY_CREATE_LIST(HttpStatus.BAD_REQUEST, "등록할 세션이 없습니다."),
 
 	// UnitPeriod Errors
 	UNIT_PERIOD_NOT_FOUND(HttpStatus.NOT_FOUND, "단위기간을 찾을 수 없습니다."),

--- a/src/main/java/com/planit/planit/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/planit/planit/global/common/exception/ErrorCode.java
@@ -36,6 +36,8 @@ public enum ErrorCode {
 	SESSION_UNIT_NO_REQUIRED(HttpStatus.BAD_REQUEST, "단위기간 번호는 필수입니다."),
 	SESSION_BEFORE_BOOTCAMP_START(HttpStatus.BAD_REQUEST, "세션 날짜는 부트캠프 시작일 이후여야 합니다."),
 	SESSION_IS_BOOTCAMP_START_DATE(HttpStatus.BAD_REQUEST, "부트캠프 시작일에 해당하는 세션은 삭제할 수 없습니다."),
+	SESSION_EMPTY_DELETE_LIST(HttpStatus.BAD_REQUEST, "삭제할 세션이 없습니다."),
+	SESSION_DIFFERENT_BOOTCAMP(HttpStatus.BAD_REQUEST, "서로 다른 부트캠프의 세션들을 함께 삭제할 수 없습니다."),
 
 	// UnitPeriod Errors
 	UNIT_PERIOD_NOT_FOUND(HttpStatus.NOT_FOUND, "단위기간을 찾을 수 없습니다."),

--- a/src/main/java/com/planit/planit/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/planit/planit/global/common/exception/ErrorCode.java
@@ -40,6 +40,7 @@ public enum ErrorCode {
 	SESSION_DIFFERENT_BOOTCAMP(HttpStatus.BAD_REQUEST, "서로 다른 부트캠프의 세션들을 함께 삭제할 수 없습니다."),
 	SESSION_DUPLICATE_DATE(HttpStatus.CONFLICT, "동일한 날짜의 세션이 이미 존재합니다."),
 	SESSION_EMPTY_CREATE_LIST(HttpStatus.BAD_REQUEST, "등록할 세션이 없습니다."),
+	SESSION_NULL_CLASS_DATE(HttpStatus.BAD_REQUEST, "세션의 수업 날짜는 필수입니다."),
 
 	// UnitPeriod Errors
 	UNIT_PERIOD_NOT_FOUND(HttpStatus.NOT_FOUND, "단위기간을 찾을 수 없습니다."),

--- a/src/main/resources/mapper/SessionMapper.xml
+++ b/src/main/resources/mapper/SessionMapper.xml
@@ -49,7 +49,7 @@
     </insert>
 
     <!-- 일괄 추가 -->
-    <insert id="insertBatch" parameterType="java.util.List">
+    <insert id="insertBatch" parameterType="java.util.List" useGeneratedKeys="true" keyProperty="id">
         INSERT INTO sessions (bootcamp_id, period_id, class_date, created_at, updated_at)
         VALUES
         <foreach collection="list" item="session" separator=",">


### PR DESCRIPTION
## ✨ 이 PR의 목적
- 기존 세션 추가, 삭제는 단건 처리만 가능해서 비효율적

## 📄 작업 내용 요약
- 세션 추가, 삭제 배열 처리를 통해 효율성 증가

## 📎 Issue 번호
- Close: #32 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 세션 다중 등록: 한 요청으로 여러 날짜의 세션을 한 번에 등록 가능.
  * 세션 일괄 삭제: 여러 세션을 한 번에 삭제 가능.

* **버그 수정 / 검증 강화**
  * 동일 날짜 중복 등록 차단 및 요청 내 중복 검증.
  * 빈 생성/삭제 요청 거부 및 클래스 날짜 필수 검증.
  * 서로 다른 강좌 세션 동시 삭제 차단 및 부트캠프 시작일 세션 삭제 방지.

* **변경사항(API)**
  * 등록 응답이 다중 세션을 반환하도록, 삭제는 일괄 삭제 요청 형태로 변경.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->