### PR TITLE
[FEAT] 전체 시간표, 출결 조회 추가

### DIFF
--- a/src/main/java/com/planit/planit/domain/session/controller/SessionController.java
+++ b/src/main/java/com/planit/planit/domain/session/controller/SessionController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.planit.planit.domain.session.dto.SessionCreateRequestDTO;
 import com.planit.planit.domain.session.dto.SessionDeleteRequestDTO;
 import com.planit.planit.domain.session.dto.SessionDTO;
+import com.planit.planit.domain.session.dto.SessionWithAttendanceDTO;
 import com.planit.planit.domain.session.service.SessionService;
 import com.planit.planit.global.common.response.ApiResponse;
 import com.planit.planit.global.common.response.ErrorDetail;
@@ -142,6 +143,29 @@ public class SessionController {
     return ResponseEntity.ok(new ApiResponse<>(HttpStatus.OK.value(), "세션 삭제 성공", null));
   }
 
+  @Operation(summary = "부트캠프 세션과 유저 출결 상태 조회", 
+      description = "특정 부트캠프의 모든 세션과 특정 유저의 출결 상태를 조회합니다.",
+      responses = {
+          @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200",
+              description = "조회 성공",
+              content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                  schema = @Schema(implementation = SessionWithAttendanceListResponseSchema.class))),
+          @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404",
+              description = "부트캠프를 찾을 수 없음",
+              content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                  schema = @Schema(implementation = ApiErrorResponseSchema.class))),
+          @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500",
+              description = "서버 에러",
+              content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                  schema = @Schema(implementation = ApiErrorResponseSchema.class)))})
+  @GetMapping("/bootcamp/{bootcampId}/user/{userId}/attendance")
+  public ResponseEntity<ApiResponse<List<SessionWithAttendanceDTO>>> getSessionsWithAttendance(
+      @PathVariable Long bootcampId, 
+      @PathVariable Long userId) {
+    List<SessionWithAttendanceDTO> sessions = sessionService.getSessionsWithAttendance(bootcampId, userId);
+    return ResponseEntity.ok(ApiResponse.success("세션과 출결 상태 조회 성공", sessions));
+  }
+
   @Schema(name = "SessionListResponse", description = "세션 목록 응답")
   static class SessionListResponseSchema {
     @Schema(example = "200")
@@ -167,6 +191,15 @@ public class SessionController {
     @Schema(example = "세션 삭제 성공")
     public String message;
     public Void data;
+  }
+
+  @Schema(name = "SessionWithAttendanceListResponse", description = "세션과 출결 상태 목록 응답")
+  static class SessionWithAttendanceListResponseSchema {
+    @Schema(example = "200")
+    public int code;
+    @Schema(example = "세션과 출결 상태 조회 성공")
+    public String message;
+    public List<SessionWithAttendanceDTO> data;
   }
 
   @Schema(name = "ApiErrorResponse", description = "실패 응답(에러)")

--- a/src/main/java/com/planit/planit/domain/session/dto/SessionWithAttendanceDTO.java
+++ b/src/main/java/com/planit/planit/domain/session/dto/SessionWithAttendanceDTO.java
@@ -1,0 +1,27 @@
+package com.planit.planit.domain.session.dto;
+
+import java.time.LocalDate;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+@Data
+@Schema(description = "세션과 출결 상태 조회 DTO")
+public class SessionWithAttendanceDTO {
+  @Schema(description = "세션 ID", example = "1")
+  private Long sessionId;
+
+  @Schema(description = "부트캠프 ID", example = "1")
+  private Long bootcampId;
+
+  @Schema(description = "단위기간 ID", example = "1")
+  private Long periodId;
+
+  @Schema(description = "단위기간 번호", example = "1")
+  private Integer unitNo;
+
+  @Schema(description = "수업 날짜", example = "2025-01-15")
+  private LocalDate classDate;
+
+  @Schema(description = "출결 상태", example = "PRESENT", allowableValues = {"PRESENT", "ABSENT", "LATE", "EXCUSED"})
+  private String attendanceStatus;
+}

--- a/src/main/java/com/planit/planit/domain/session/mapper/SessionMapper.java
+++ b/src/main/java/com/planit/planit/domain/session/mapper/SessionMapper.java
@@ -2,7 +2,9 @@ package com.planit.planit.domain.session.mapper;
 
 import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 import com.planit.planit.domain.session.dto.SessionDTO;
+import com.planit.planit.domain.session.dto.SessionWithAttendanceDTO;
 
 @Mapper
 public interface SessionMapper {
@@ -19,4 +21,8 @@ public interface SessionMapper {
     void delete(Long id);
 
     void deleteByBootcampId(Long bootcampId);
+
+    List<SessionWithAttendanceDTO> findSessionsWithAttendanceByBootcampIdAndUserId(
+        @Param("bootcampId") Long bootcampId, 
+        @Param("userId") Long userId);
 }

--- a/src/main/java/com/planit/planit/domain/session/service/SessionService.java
+++ b/src/main/java/com/planit/planit/domain/session/service/SessionService.java
@@ -11,6 +11,7 @@ import com.planit.planit.domain.bootcamp.service.BootcampService;
 import com.planit.planit.domain.session.dto.SessionDTO;
 import com.planit.planit.domain.session.dto.SessionCreateItemDTO;
 import com.planit.planit.domain.session.dto.SessionDeleteRequestDTO;
+import com.planit.planit.domain.session.dto.SessionWithAttendanceDTO;
 import com.planit.planit.domain.session.exception.SessionBeforeBootcampStartException;
 import com.planit.planit.domain.session.exception.SessionIsBootcampStartDateException;
 import com.planit.planit.domain.session.exception.SessionNotFoundException;
@@ -212,6 +213,13 @@ public class SessionService {
 
 		// 부트캠프의 시작일/종료일 갱신
 		bootcampService.updateBootcampDates(bootcampId);
+	}
+
+	public List<SessionWithAttendanceDTO> getSessionsWithAttendance(Long bootcampId, Long userId) {
+		// 부트캠프 존재 여부 검증
+		bootcampService.getBootcamp(bootcampId);
+		
+		return sessionMapper.findSessionsWithAttendanceByBootcampIdAndUserId(bootcampId, userId);
 	}
 
 	/**

--- a/src/main/resources/mapper/SessionMapper.xml
+++ b/src/main/resources/mapper/SessionMapper.xml
@@ -79,7 +79,7 @@
             a.status as "attendanceStatus"
         FROM sessions s
         LEFT JOIN unit_periods up ON s.period_id = up.id
-        LEFT JOIN attendances a ON s.id = a.session_id AND a.user_id = #{userId}
+        LEFT JOIN attendance a ON s.id = a.session_id AND a.user_id = #{userId}
         WHERE s.bootcamp_id = #{bootcampId}
         ORDER BY s.class_date ASC
     </select>

--- a/src/main/resources/mapper/SessionMapper.xml
+++ b/src/main/resources/mapper/SessionMapper.xml
@@ -67,4 +67,21 @@
         DELETE FROM sessions WHERE bootcamp_id = #{bootcampId}
     </delete>
 
+    <!-- 부트캠프별 세션과 특정 유저의 출결 상태 조회 -->
+    <select id="findSessionsWithAttendanceByBootcampIdAndUserId" 
+            resultType="com.planit.planit.domain.session.dto.SessionWithAttendanceDTO">
+        SELECT 
+            s.id as "sessionId",
+            s.bootcamp_id as "bootcampId",
+            s.period_id as "periodId",
+            up.unit_no as "unitNo",
+            s.class_date as "classDate",
+            a.status as "attendanceStatus"
+        FROM sessions s
+        LEFT JOIN unit_periods up ON s.period_id = up.id
+        LEFT JOIN attendances a ON s.id = a.session_id AND a.user_id = #{userId}
+        WHERE s.bootcamp_id = #{bootcampId}
+        ORDER BY s.class_date ASC
+    </select>
+
 </mapper>


### PR DESCRIPTION
## ✨ 이 PR의 목적
- 부트캠프의 전체 시간표와 출결 정보를 한번에 조회하기 위해 필요함

## 📄 작업 내용 요약
- 부트캠프의 전체 시간표와 출결 정보를 응답하는 API 추가

## 📎 Issue 번호
- Close: #38 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 부트캠프 참가자의 세션별 출결 현황을 조회할 수 있는 새로운 API 엔드포인트가 추가되었습니다.
  * 사용자는 특정 부트캠프의 모든 세션에 대한 수업 날짜 및 출결 상태 정보를 한 번에 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->