### PR TITLE
[FEAT] 부트캠프 리스트 페이지 별 조회 추가

### DIFF
--- a/src/main/java/com/planit/planit/domain/bootcamp/controller/BootcampController.java
+++ b/src/main/java/com/planit/planit/domain/bootcamp/controller/BootcampController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import com.planit.planit.domain.bootcamp.dto.BootcampParseRequestDTO;
 import com.planit.planit.domain.bootcamp.dto.BootcampParseResponseDTO;
@@ -20,6 +21,7 @@ import com.planit.planit.domain.bootcamp.service.BootcampService;
 import com.planit.planit.global.common.response.ApiResponse;
 import com.planit.planit.global.common.response.ErrorDetail;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -36,7 +38,7 @@ public class BootcampController {
 		this.bootcampService = bootcampService;
 	}
 
-	@Operation(summary = "부트캠프 전체 목록 조회", description = "등록된 모든 부트캠프 목록을 조회합니다.",
+	@Operation(summary = "부트캠프 전체 목록 조회", description = "등록된 모든 부트캠프 목록을 조회합니다. 페이지네이션을 지원합니다.",
 		responses = {
 			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200",
 				description = "조회 성공",
@@ -47,8 +49,12 @@ public class BootcampController {
 				content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
 					schema = @Schema(implementation = ApiErrorResponseSchema.class)))})
 	@GetMapping
-	public ResponseEntity<ApiResponse<List<BootcampResponseDTO>>> getAll() {
-		List<BootcampResponseDTO> bootcamps = bootcampService.getAllBootcamps();
+	public ResponseEntity<ApiResponse<List<BootcampResponseDTO>>> getAll(
+		@Parameter(description = "페이지 번호 (기본값: 1)", example = "1")
+		@RequestParam(value = "page", defaultValue = "1") int page,
+		@Parameter(description = "페이지당 표시할 개수 (기본값: 10)", example = "10")
+		@RequestParam(value = "size", defaultValue = "10") int size) {
+		List<BootcampResponseDTO> bootcamps = bootcampService.getAllBootcampsWithPagination(page, size);
 		return ResponseEntity.ok(ApiResponse.success("부트캠프 목록 조회 성공", bootcamps));
 	}
 

--- a/src/main/java/com/planit/planit/domain/bootcamp/controller/BootcampController.java
+++ b/src/main/java/com/planit/planit/domain/bootcamp/controller/BootcampController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import com.planit.planit.domain.bootcamp.dto.BootcampListSummaryResponseDTO;
 import com.planit.planit.domain.bootcamp.dto.BootcampParseRequestDTO;
 import com.planit.planit.domain.bootcamp.dto.BootcampParseResponseDTO;
 import com.planit.planit.domain.bootcamp.dto.BootcampRequestDTO;
@@ -38,7 +39,23 @@ public class BootcampController {
 		this.bootcampService = bootcampService;
 	}
 
-	@Operation(summary = "부트캠프 전체 목록 조회", description = "등록된 모든 부트캠프 목록을 조회합니다. 페이지네이션을 지원합니다.",
+	@Operation(summary = "부트캠프 전체 목록 조회 (요약)", description = "등록된 모든 부트캠프 목록과 개수 정보를 조회합니다.",
+		responses = {
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200",
+				description = "조회 성공",
+				content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+					schema = @Schema(implementation = BootcampListSummaryResponseSchema.class))),
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500",
+				description = "서버 에러",
+				content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+					schema = @Schema(implementation = ApiErrorResponseSchema.class)))})
+	@GetMapping("/summary")
+	public ResponseEntity<ApiResponse<BootcampListSummaryResponseDTO>> getAllSummary() {
+		BootcampListSummaryResponseDTO summary = bootcampService.getAllBootcamps();
+		return ResponseEntity.ok(ApiResponse.success("부트캠프 목록 조회 성공", summary));
+	}
+
+	@Operation(summary = "부트캠프 목록 조회 (페이지네이션)", description = "등록된 부트캠프 목록을 페이지네이션으로 조회합니다.",
 		responses = {
 			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200",
 				description = "조회 성공",
@@ -179,6 +196,15 @@ public class BootcampController {
 		@Schema(example = "부트캠프 목록 조회 성공")
 		public String message;
 		public List<BootcampResponseDTO> data;
+	}
+
+	@Schema(name = "BootcampListSummaryResponse", description = "부트캠프 목록 요약 응답")
+	static class BootcampListSummaryResponseSchema {
+		@Schema(example = "200")
+		public int code;
+		@Schema(example = "부트캠프 목록 조회 성공")
+		public String message;
+		public BootcampListSummaryResponseDTO data;
 	}
 
 	@Schema(name = "BootcampOneResponse", description = "부트캠프 단건 응답")

--- a/src/main/java/com/planit/planit/domain/bootcamp/dto/BootcampListSummaryResponseDTO.java
+++ b/src/main/java/com/planit/planit/domain/bootcamp/dto/BootcampListSummaryResponseDTO.java
@@ -1,6 +1,5 @@
 package com.planit.planit.domain.bootcamp.dto;
 
-import java.util.List;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
@@ -10,10 +9,7 @@ public class BootcampListSummaryResponseDTO {
 	@Schema(description = "전체 부트캠프 개수", example = "50")
 	private Long totalCount;
 
-	@Schema(description = "종료되지 않은 부트캠프 개수", example = "30")
+	@Schema(description = "진행중인 부트캠프 개수", example = "30")
 	private Long activeCount;
-
-	@Schema(description = "부트캠프 목록")
-	private List<BootcampResponseDTO> bootcamps;
 }
 

--- a/src/main/java/com/planit/planit/domain/bootcamp/dto/BootcampListSummaryResponseDTO.java
+++ b/src/main/java/com/planit/planit/domain/bootcamp/dto/BootcampListSummaryResponseDTO.java
@@ -1,0 +1,19 @@
+package com.planit.planit.domain.bootcamp.dto;
+
+import java.util.List;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+@Data
+@Schema(description = "부트캠프 목록 요약 응답 DTO")
+public class BootcampListSummaryResponseDTO {
+	@Schema(description = "전체 부트캠프 개수", example = "50")
+	private Long totalCount;
+
+	@Schema(description = "종료되지 않은 부트캠프 개수", example = "30")
+	private Long activeCount;
+
+	@Schema(description = "부트캠프 목록")
+	private List<BootcampResponseDTO> bootcamps;
+}
+

--- a/src/main/java/com/planit/planit/domain/bootcamp/dto/BootcampResponseDTO.java
+++ b/src/main/java/com/planit/planit/domain/bootcamp/dto/BootcampResponseDTO.java
@@ -27,6 +27,9 @@ public class BootcampResponseDTO {
 	@Schema(description = "부트캠프 종료일 (세션 기반 자동 갱신)", example = "2025-06-30")
 	private LocalDate endedAt;
 
+	@Schema(description = "부트캠프 종료 여부", example = "false")
+	private Boolean isEnded;
+
 	@Schema(description = "교육일 목록 (첫 날짜가 기준일이 되어 단위기간 자동 생성)",
 		example = "[\"2025-01-25\", \"2025-01-26\", \"2025-01-27\"]")
 	private List<LocalDate> classDates;

--- a/src/main/java/com/planit/planit/domain/bootcamp/mapper/BootcampMapper.java
+++ b/src/main/java/com/planit/planit/domain/bootcamp/mapper/BootcampMapper.java
@@ -3,13 +3,16 @@ package com.planit.planit.domain.bootcamp.mapper;
 import java.time.LocalDate;
 import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
 import com.planit.planit.domain.bootcamp.dto.BootcampDTO;
 
 @Mapper
 public interface BootcampMapper {
   List<BootcampDTO> findAll();
 
-  List<BootcampDTO> findAllWithPagination(int offset, int limit);
+  List<BootcampDTO> findAllWithPagination(@Param("offset") int offset,
+                                        @Param("limit") int limit);
 
   BootcampDTO findById(Long id);
 

--- a/src/main/java/com/planit/planit/domain/bootcamp/mapper/BootcampMapper.java
+++ b/src/main/java/com/planit/planit/domain/bootcamp/mapper/BootcampMapper.java
@@ -9,6 +9,8 @@ import com.planit.planit.domain.bootcamp.dto.BootcampDTO;
 public interface BootcampMapper {
   List<BootcampDTO> findAll();
 
+  List<BootcampDTO> findAllWithPagination(int offset, int limit);
+
   BootcampDTO findById(Long id);
 
   BootcampDTO findByIdForUpdate(Long id);

--- a/src/main/java/com/planit/planit/domain/bootcamp/mapper/BootcampMapper.java
+++ b/src/main/java/com/planit/planit/domain/bootcamp/mapper/BootcampMapper.java
@@ -14,6 +14,10 @@ public interface BootcampMapper {
   List<BootcampDTO> findAllWithPagination(@Param("offset") int offset,
                                         @Param("limit") int limit);
 
+  Long countAll();
+
+  Long countActive();
+
   BootcampDTO findById(Long id);
 
   BootcampDTO findByIdForUpdate(Long id);

--- a/src/main/java/com/planit/planit/domain/bootcamp/service/BootcampService.java
+++ b/src/main/java/com/planit/planit/domain/bootcamp/service/BootcampService.java
@@ -38,18 +38,12 @@ public class BootcampService {
 	}
 
 	public BootcampListSummaryResponseDTO getAllBootcamps() {
-		List<BootcampDTO> bootcamps = bootcampMapper.findAll();
-		List<BootcampResponseDTO> bootcampResponses = bootcamps.stream()
-			.map(this::toResponseDTO)
-			.collect(Collectors.toList());
-		
 		Long totalCount = bootcampMapper.countAll();
 		Long activeCount = bootcampMapper.countActive();
 		
 		BootcampListSummaryResponseDTO response = new BootcampListSummaryResponseDTO();
 		response.setTotalCount(totalCount);
 		response.setActiveCount(activeCount);
-		response.setBootcamps(bootcampResponses);
 		
 		return response;
 	}

--- a/src/main/java/com/planit/planit/domain/bootcamp/service/BootcampService.java
+++ b/src/main/java/com/planit/planit/domain/bootcamp/service/BootcampService.java
@@ -41,6 +41,12 @@ public class BootcampService {
 		return bootcamps.stream().map(this::toResponseDTO).collect(Collectors.toList());
 	}
 
+	public List<BootcampResponseDTO> getAllBootcampsWithPagination(int page, int size) {
+		int offset = (page - 1) * size;
+		List<BootcampDTO> bootcamps = bootcampMapper.findAllWithPagination(offset, size);
+		return bootcamps.stream().map(this::toResponseDTO).collect(Collectors.toList());
+	}
+
 	public BootcampResponseDTO getBootcamp(Long id) {
 		BootcampDTO bootcamp = bootcampMapper.findById(id);
 		if (bootcamp == null) {

--- a/src/main/java/com/planit/planit/domain/bootcamp/service/BootcampService.java
+++ b/src/main/java/com/planit/planit/domain/bootcamp/service/BootcampService.java
@@ -42,10 +42,20 @@ public class BootcampService {
 	}
 
 	public List<BootcampResponseDTO> getAllBootcampsWithPagination(int page, int size) {
-		int offset = (page - 1) * size;
-		List<BootcampDTO> bootcamps = bootcampMapper.findAllWithPagination(offset, size);
-		return bootcamps.stream().map(this::toResponseDTO).collect(Collectors.toList());
-	}
+    if (page < 1) {
+        page = 1;
+    }
+    int maxSize = 50; 
+    if (size < 1) {
+        size = 10;
+    } else if (size > maxSize) {
+        size = maxSize;
+    }
+
+    int offset = (page - 1) * size;
+    List<BootcampDTO> bootcamps = bootcampMapper.findAllWithPagination(offset, size);
+    return bootcamps.stream().map(this::toResponseDTO).collect(Collectors.toList());
+}
 
 	public BootcampResponseDTO getBootcamp(Long id) {
 		BootcampDTO bootcamp = bootcampMapper.findById(id);
@@ -302,6 +312,13 @@ public class BootcampService {
 		response.setClassDates(dto.getClassDates());
 		response.setCreatedAt(dto.getCreatedAt());
 		response.setUpdatedAt(dto.getUpdatedAt());
+		
+		if (dto.getEndedAt() != null) {
+			response.setIsEnded(dto.getEndedAt().isBefore(LocalDate.now()));
+		} else {
+			response.setIsEnded(false);
+		}
+		
 		return response;
 	}
 

--- a/src/main/java/com/planit/planit/domain/bootcamp/service/BootcampService.java
+++ b/src/main/java/com/planit/planit/domain/bootcamp/service/BootcampService.java
@@ -7,6 +7,7 @@ import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import com.planit.planit.domain.bootcamp.dto.BootcampDTO;
+import com.planit.planit.domain.bootcamp.dto.BootcampListSummaryResponseDTO;
 import com.planit.planit.domain.bootcamp.dto.BootcampRequestDTO;
 import com.planit.planit.domain.bootcamp.dto.BootcampResponseDTO;
 import com.planit.planit.domain.bootcamp.exception.BootcampInvalidClassDatesException;
@@ -36,9 +37,21 @@ public class BootcampService {
 		this.unitPeriodCalculator = unitPeriodCalculator;
 	}
 
-	public List<BootcampResponseDTO> getAllBootcamps() {
+	public BootcampListSummaryResponseDTO getAllBootcamps() {
 		List<BootcampDTO> bootcamps = bootcampMapper.findAll();
-		return bootcamps.stream().map(this::toResponseDTO).collect(Collectors.toList());
+		List<BootcampResponseDTO> bootcampResponses = bootcamps.stream()
+			.map(this::toResponseDTO)
+			.collect(Collectors.toList());
+		
+		Long totalCount = bootcampMapper.countAll();
+		Long activeCount = bootcampMapper.countActive();
+		
+		BootcampListSummaryResponseDTO response = new BootcampListSummaryResponseDTO();
+		response.setTotalCount(totalCount);
+		response.setActiveCount(activeCount);
+		response.setBootcamps(bootcampResponses);
+		
+		return response;
 	}
 
 	public List<BootcampResponseDTO> getAllBootcampsWithPagination(int page, int size) {

--- a/src/main/resources/mapper/BootcampMapper.xml
+++ b/src/main/resources/mapper/BootcampMapper.xml
@@ -22,6 +22,17 @@
 		LIMIT #{limit} OFFSET #{offset}
 	</select>
 
+	<!-- 전체 부트캠프 개수 조회 -->
+	<select id="countAll" resultType="long">
+		SELECT COUNT(*) FROM bootcamps
+	</select>
+
+	<!-- 종료되지 않은 부트캠프 개수 조회 -->
+	<select id="countActive" resultType="long">
+		SELECT COUNT(*) FROM bootcamps
+		WHERE ended_at IS NULL OR ended_at >= CURDATE()
+	</select>
+
 	<!-- 단일 조회 -->
 	<select id="findById" parameterType="long" resultType="com.planit.planit.domain.bootcamp.dto.BootcampDTO">
 		SELECT id, name, organizer, is_kdt as "isKdt", started_at as "startedAt", ended_at as "endedAt",

--- a/src/main/resources/mapper/BootcampMapper.xml
+++ b/src/main/resources/mapper/BootcampMapper.xml
@@ -13,6 +13,15 @@
 		ORDER BY created_at DESC
 	</select>
 
+	<!-- 페이지네이션을 사용한 전체 조회 -->
+	<select id="findAllWithPagination" resultType="com.planit.planit.domain.bootcamp.dto.BootcampDTO">
+		SELECT id, name, organizer, is_kdt as "isKdt", started_at as "startedAt", ended_at as "endedAt",
+			   created_at as "createdAt", updated_at as "updatedAt"
+		FROM bootcamps
+		ORDER BY created_at DESC
+		LIMIT #{limit} OFFSET #{offset}
+	</select>
+
 	<!-- 단일 조회 -->
 	<select id="findById" parameterType="long" resultType="com.planit.planit.domain.bootcamp.dto.BootcampDTO">
 		SELECT id, name, organizer, is_kdt as "isKdt", started_at as "startedAt", ended_at as "endedAt",


### PR DESCRIPTION
## ✨ 이 PR의 목적
- 부트캠프 리스트 조회 시 전체 조회 밖에 없어서 부트캠프의 수가 늘어나면 문제 발생

## 📄 작업 내용 요약
-  부트캠프 리스트 무한 스크롤 조회를 위해 페이지 별 조회 추가

## 📎 Issue 번호
- Close: #46 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 부트캠프 목록에 페이지네이션이 도입되었습니다 — 페이지 번호와 페이지당 항목 수로 조회 가능(기본: 페이지 1, 10개).
  * 요약 응답(전체 개수, 활성 개수 및 요약된 부트캠프 목록)을 반환하는 새로운 요약 엔드포인트가 추가되었습니다.
  * 각 부트캠프에 종료 여부(isEnded) 정보가 추가되어 진행 상태를 명확히 확인할 수 있습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->