### PR TITLE
[FIX] 부트캠프 응답 수정

### DIFF
--- a/src/main/java/com/planit/planit/domain/bootcamp/controller/BootcampController.java
+++ b/src/main/java/com/planit/planit/domain/bootcamp/controller/BootcampController.java
@@ -75,7 +75,7 @@ public class BootcampController {
 		return ResponseEntity.ok(ApiResponse.success("부트캠프 목록 조회 성공", bootcamps));
 	}
 
-	@Operation(summary = "부트캠프 검색", description = "부트캠프 이름 또는 기관명으로 검색합니다. 페이지네이션을 지원합니다.",
+	@Operation(summary = "부트캠프 검색", description = "부트캠프 이름 또는 기관명으로 검색합니다. 페이지네이션을 지원합니다. keyword가 없으면 전체 목록을 반환합니다.",
 		responses = {
 			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200",
 				description = "검색 성공",
@@ -87,8 +87,8 @@ public class BootcampController {
 					schema = @Schema(implementation = ApiErrorResponseSchema.class)))})
 	@GetMapping("/search")
 	public ResponseEntity<ApiResponse<List<BootcampResponseDTO>>> search(
-		@Parameter(description = "검색 키워드 (부트캠프 이름 또는 기관명)", example = "LG")
-		@RequestParam(value = "keyword") String keyword,
+		@Parameter(description = "검색 키워드 (부트캠프 이름 또는 기관명, 선택사항)", example = "LG")
+		@RequestParam(value = "keyword", required = false) String keyword,
 		@Parameter(description = "페이지 번호 (기본값: 1)", example = "1")
 		@RequestParam(value = "page", defaultValue = "1") int page,
 		@Parameter(description = "페이지당 표시할 개수 (기본값: 10)", example = "10")

--- a/src/main/java/com/planit/planit/domain/bootcamp/service/BootcampService.java
+++ b/src/main/java/com/planit/planit/domain/bootcamp/service/BootcampService.java
@@ -2,7 +2,9 @@ package com.planit.planit.domain.bootcamp.service;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -79,10 +81,12 @@ public class BootcampService {
 		PaginationInfo pagination = validateAndCalculatePagination(page, size);
 
 		List<BootcampDTO> bootcamps = bootcampMapper.findAllWithPagination(pagination.offset(), pagination.size());
-		return bootcamps.stream()
+		List<BootcampResponseDTO> responses = bootcamps.stream()
 			.map(this::toResponseDTO)
-			.map(this::enrichWithClassDates)
 			.collect(Collectors.toList());
+		
+		enrichWithClassDatesBatch(responses);
+		return responses;
 	}
 
 	public List<BootcampResponseDTO> searchBootcamps(String keyword, int page, int size) {
@@ -93,10 +97,12 @@ public class BootcampService {
 		PaginationInfo pagination = validateAndCalculatePagination(page, size);
 
 		List<BootcampDTO> bootcamps = bootcampMapper.search(keyword.trim(), pagination.offset(), pagination.size());
-		return bootcamps.stream()
+		List<BootcampResponseDTO> responses = bootcamps.stream()
 			.map(this::toResponseDTO)
-			.map(this::enrichWithClassDates)
 			.collect(Collectors.toList());
+		
+		enrichWithClassDatesBatch(responses);
+		return responses;
 	}
 
 	public BootcampResponseDTO getBootcamp(Long id) {
@@ -365,7 +371,7 @@ public class BootcampService {
 	}
 
 	/**
-	 * Response DTO에 세션에서 추출한 classDates를 채웁니다.
+	 * Response DTO에 세션에서 추출한 classDates를 채웁니다. (단건 조회용)
 	 */
 	private BootcampResponseDTO enrichWithClassDates(BootcampResponseDTO response) {
 		List<SessionDTO> sessions = sessionMapper.findByBootcampId(response.getId());
@@ -375,6 +381,44 @@ public class BootcampService {
 			response.setClassDates(classDates);
 		}
 		return response;
+	}
+
+	/**
+	 * 여러 부트캠프의 Response DTO에 세션에서 추출한 classDates를 배치로 채웁니다.
+	 * N+1 쿼리 문제를 해결하기 위해 한 번의 쿼리로 모든 세션을 조회합니다.
+	 */
+	private void enrichWithClassDatesBatch(List<BootcampResponseDTO> responses) {
+		if (responses == null || responses.isEmpty()) {
+			return;
+		}
+
+		// 부트캠프 ID 리스트 추출
+		List<Long> bootcampIds = responses.stream()
+			.map(BootcampResponseDTO::getId)
+			.collect(Collectors.toList());
+
+		if (bootcampIds.isEmpty()) {
+			return;
+		}
+
+		// 한 번의 쿼리로 모든 세션 조회
+		List<SessionDTO> allSessions = sessionMapper.findByBootcampIds(bootcampIds);
+
+		// 부트캠프 ID별로 세션을 그룹화
+		Map<Long, List<SessionDTO>> sessionsByBootcampId = allSessions.stream()
+			.collect(Collectors.groupingBy(SessionDTO::getBootcampId));
+
+		// 각 부트캠프에 해당하는 세션의 classDate를 추출하여 설정
+		for (BootcampResponseDTO response : responses) {
+			List<SessionDTO> sessions = sessionsByBootcampId.getOrDefault(response.getId(), Collections.emptyList());
+			if (!sessions.isEmpty()) {
+				List<LocalDate> classDates = sessions.stream()
+					.map(SessionDTO::getClassDate)
+					.sorted()
+					.collect(Collectors.toList());
+				response.setClassDates(classDates);
+			}
+		}
 	}
 
 	/**

--- a/src/main/java/com/planit/planit/domain/bootcamp/service/BootcampService.java
+++ b/src/main/java/com/planit/planit/domain/bootcamp/service/BootcampService.java
@@ -79,7 +79,10 @@ public class BootcampService {
 		PaginationInfo pagination = validateAndCalculatePagination(page, size);
 
 		List<BootcampDTO> bootcamps = bootcampMapper.findAllWithPagination(pagination.offset(), pagination.size());
-		return bootcamps.stream().map(this::toResponseDTO).collect(Collectors.toList());
+		return bootcamps.stream()
+			.map(this::toResponseDTO)
+			.map(this::enrichWithClassDates)
+			.collect(Collectors.toList());
 	}
 
 	public List<BootcampResponseDTO> searchBootcamps(String keyword, int page, int size) {
@@ -90,7 +93,10 @@ public class BootcampService {
 		PaginationInfo pagination = validateAndCalculatePagination(page, size);
 
 		List<BootcampDTO> bootcamps = bootcampMapper.search(keyword.trim(), pagination.offset(), pagination.size());
-		return bootcamps.stream().map(this::toResponseDTO).collect(Collectors.toList());
+		return bootcamps.stream()
+			.map(this::toResponseDTO)
+			.map(this::enrichWithClassDates)
+			.collect(Collectors.toList());
 	}
 
 	public BootcampResponseDTO getBootcamp(Long id) {
@@ -355,6 +361,19 @@ public class BootcampService {
 			response.setIsEnded(false);
 		}
 		
+		return response;
+	}
+
+	/**
+	 * Response DTO에 세션에서 추출한 classDates를 채웁니다.
+	 */
+	private BootcampResponseDTO enrichWithClassDates(BootcampResponseDTO response) {
+		List<SessionDTO> sessions = sessionMapper.findByBootcampId(response.getId());
+		if (sessions != null && !sessions.isEmpty()) {
+			List<LocalDate> classDates =
+				sessions.stream().map(SessionDTO::getClassDate).sorted().collect(Collectors.toList());
+			response.setClassDates(classDates);
+		}
 		return response;
 	}
 

--- a/src/main/java/com/planit/planit/domain/bootcamp/service/BootcampService.java
+++ b/src/main/java/com/planit/planit/domain/bootcamp/service/BootcampService.java
@@ -371,19 +371,6 @@ public class BootcampService {
 	}
 
 	/**
-	 * Response DTO에 세션에서 추출한 classDates를 채웁니다. (단건 조회용)
-	 */
-	private BootcampResponseDTO enrichWithClassDates(BootcampResponseDTO response) {
-		List<SessionDTO> sessions = sessionMapper.findByBootcampId(response.getId());
-		if (sessions != null && !sessions.isEmpty()) {
-			List<LocalDate> classDates =
-				sessions.stream().map(SessionDTO::getClassDate).sorted().collect(Collectors.toList());
-			response.setClassDates(classDates);
-		}
-		return response;
-	}
-
-	/**
 	 * 여러 부트캠프의 Response DTO에 세션에서 추출한 classDates를 배치로 채웁니다.
 	 * N+1 쿼리 문제를 해결하기 위해 한 번의 쿼리로 모든 세션을 조회합니다.
 	 */

--- a/src/main/java/com/planit/planit/domain/session/mapper/SessionMapper.java
+++ b/src/main/java/com/planit/planit/domain/session/mapper/SessionMapper.java
@@ -12,6 +12,8 @@ public interface SessionMapper {
 
     List<SessionDTO> findByBootcampId(Long bootcampId);
 
+    List<SessionDTO> findByBootcampIds(@Param("bootcampIds") List<Long> bootcampIds);
+
     SessionDTO findById(Long id);
 
     void insert(SessionDTO session);

--- a/src/main/resources/mapper/SessionMapper.xml
+++ b/src/main/resources/mapper/SessionMapper.xml
@@ -30,6 +30,22 @@
         ORDER BY s.class_date ASC
     </select>
 
+    <!-- 부트캠프 ID 리스트로 배치 조회 -->
+    <select id="findByBootcampIds" resultType="com.planit.planit.domain.session.dto.SessionDTO">
+        SELECT s.id, s.bootcamp_id as "bootcampId", s.period_id as "periodId",
+               up.unit_no as "unitNo",
+               up.start_date as "periodStartDate",
+               up.end_date as "periodEndDate",
+               s.class_date as "classDate", s.created_at as "createdAt", s.updated_at as "updatedAt"
+        FROM sessions s
+        LEFT JOIN unit_periods up ON s.period_id = up.id
+        WHERE s.bootcamp_id IN
+        <foreach collection="bootcampIds" item="bootcampId" open="(" separator="," close=")">
+            #{bootcampId}
+        </foreach>
+        ORDER BY s.bootcamp_id ASC, s.class_date ASC
+    </select>
+
     <!-- 단일 조회 -->
     <select id="findById" parameterType="long" resultType="com.planit.planit.domain.session.dto.SessionDTO">
         SELECT s.id, s.bootcamp_id as "bootcampId", s.period_id as "periodId",


### PR DESCRIPTION
## ✨ 이 PR의 목적
- 프론트에 맞춘 응답
- 스웨거 테스트 용이성

## 📄 작업 내용 요약
- classDates 데이터 정상 응답
- bootcamp search keyword required 해제

## 📎 Issue 번호
- Close: #54 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 부트캠프 검색에서 검색어 선택화(미입력 시 전체 목록 반환)
  * 부트캠프 조회 결과에 강좌 일정(수업일) 정보 추가

* **개선사항**
  * 검색 엔드포인트 설명 개선으로 사용성 향상
  * 여러 부트캠프의 일정 정보를 일괄적으로 조회해 성능 및 응답 일관성 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->