### PR TITLE
[FIX] 훈련지원금 로직 변경, 출결 등록시 병가사용제한

### DIFF
--- a/src/main/java/com/planit/planit/domain/attendance/controller/AttendanceController.java
+++ b/src/main/java/com/planit/planit/domain/attendance/controller/AttendanceController.java
@@ -66,6 +66,8 @@ public class AttendanceController {
       - left_early: 조퇴
       - annual: 연차
       - leave: 공가
+      - outing: 외출
+      - sick_leave: 병가
       """,
       responses = {@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200",
           description = "출결 등록 성공")})
@@ -143,9 +145,9 @@ public class AttendanceController {
     return ApiResponse.success(attendance);
   }
 
-  @Operation(summary = "월차 잔여/누적 사용량 조회", description = "현재까지 사용한 월차, 받았던월차, 남은월차를 조회합니다. ",
+  @Operation(summary = "월차/ 병가 사용량 조회", description = "현재까지 사용한 월차/병가, 받았던월차/병가, 남은월차/병가를 조회합니다. ",
       responses = {@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200",
-          description = "월차 잔여 조회 성공",
+          description = "월차/병가 잔여 조회 성공",
           content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
               schema = @Schema(implementation = LeaveBalanceResponseDTO.class)))})
   @GetMapping("/balance/{userId}")

--- a/src/main/java/com/planit/planit/domain/attendance/dto/AttendancePeriodResponseDTO.java
+++ b/src/main/java/com/planit/planit/domain/attendance/dto/AttendancePeriodResponseDTO.java
@@ -15,8 +15,10 @@ public class AttendancePeriodResponseDTO {
   private Integer absentCount;
   private Integer lateCount;
   private Integer leftEarlyCount;
+  private Integer outingCount;
   private Integer annualCount;
   private Integer leaveCount;
+  private Integer sickLeaveCount;
 
   private Integer totalPresentCount; // 실제 총 출석수 (출석,지각,조퇴,연차,휴가의합 에서 (지각+조퇴)/3 뺀값)
   private Integer totalAbsentCount;// 실제 총 결석수(결석+(지각+조퇴)/3)

--- a/src/main/java/com/planit/planit/domain/attendance/dto/AttendanceTotalResponseDTO.java
+++ b/src/main/java/com/planit/planit/domain/attendance/dto/AttendanceTotalResponseDTO.java
@@ -10,8 +10,10 @@ public class AttendanceTotalResponseDTO {
   private Integer absentCount;
   private Integer lateCount;
   private Integer leftEarlyCount;
+  private Integer outingCount;
   private Integer annualCount;
   private Integer leaveCount;
+  private Integer sickLeaveCount;
 
   private Integer totalPresentCount; // 실제 총 출석수 (출석,지각,조퇴,연차,휴가의합 에서 (지각+조퇴)/3 뺀값)
   private Integer totalAbsentCount;// 실제 총 결석수(결석+(지각+조퇴)/3)

--- a/src/main/java/com/planit/planit/domain/attendance/dto/LeaveBalanceResponseDTO.java
+++ b/src/main/java/com/planit/planit/domain/attendance/dto/LeaveBalanceResponseDTO.java
@@ -7,5 +7,8 @@ public class LeaveBalanceResponseDTO {
   private int usedAnnual;// 사용한 연차
   private int totalAnnual;// 현재까지 받은 모든 연차
   private int remainingAnnual;// 남은 연차
+  private int usedSickLeave;// 사용한 병가
+  private int totalSickLeave;// 훈련기간중 사용할수있는 병가 수
+  private int remainingSickLeave;// 남은 병가
 
 }

--- a/src/main/java/com/planit/planit/domain/attendance/enums/AttendanceStatus.java
+++ b/src/main/java/com/planit/planit/domain/attendance/enums/AttendanceStatus.java
@@ -5,8 +5,10 @@ public enum AttendanceStatus {
   absent, // 결석
   late, // 지각
   left_early, // 조퇴
+  outing, // 외출
   annual, // 연차
   leave, // 공가
+  sick_leave, // 병가
   no_session, // 강의없음
   no_attendance // 미출결
 }

--- a/src/main/java/com/planit/planit/domain/attendance/service/AttendanceService.java
+++ b/src/main/java/com/planit/planit/domain/attendance/service/AttendanceService.java
@@ -91,13 +91,20 @@ public class AttendanceService {
 
     }
 
-    // 남은연차개수 체크
+    // 남은월차/병가 개수 체크
     LeaveBalanceResponseDTO leavebalance =
         mapper.getBalanceLeave(requestDTO.getUserId(), requestDTO.getBootcampId());
+
     if (requestDTO.getStatus() == AttendanceStatus.annual
         && leavebalance.getRemainingAnnual() < classDates.size()) {
       throw new BaseException(ErrorCode.RESOURCE_NOT_FOUND,
-          "남은 연차보다 더 많이 등록하셨습니다. 남은연차 " + leavebalance.getRemainingAnnual()) {};
+          "남은 월차보다 더 많이 등록하셨습니다. 남은월차 " + leavebalance.getRemainingAnnual()) {};
+    }
+
+    if (requestDTO.getStatus() == AttendanceStatus.sick_leave
+        && leavebalance.getRemainingSickLeave() < classDates.size()) {
+      throw new BaseException(ErrorCode.RESOURCE_NOT_FOUND,
+          "남은 병가보다 더 많이 등록하셨습니다. 남은병가 " + leavebalance.getRemainingSickLeave()) {};
     }
 
     // 이미 등록된 출결 확인
@@ -211,26 +218,39 @@ public class AttendanceService {
       throw new BaseException(ErrorCode.RESOURCE_NOT_FOUND, "해당 단위기간에 등록된 출결이 없습니다.") {};
     }
 
-    // 출석,지각,조퇴,연차,휴가의 합
+    // 출석,지각,조퇴,월차,공가,외출,병가의 합
     Integer totalPresentCount = attendance.getPresentCount() + attendance.getLateCount()
-        + attendance.getLeftEarlyCount() + attendance.getAnnualCount() + attendance.getLeaveCount();
+        + attendance.getLeftEarlyCount() + attendance.getAnnualCount() + attendance.getLeaveCount()
+        + attendance.getOutingCount() + attendance.getSickLeaveCount();
 
     // 지각+조퇴 3회 쌓인거 출석수에 반영
-    totalPresentCount -= (attendance.getLateCount() + attendance.getLeftEarlyCount()) / 3;
+    totalPresentCount -=
+        (attendance.getLateCount() + attendance.getLeftEarlyCount() + attendance.getOutingCount())
+            / 3;
 
     // 실제 총 결석수
     Integer totalAbsentCount = attendance.getAbsentCount()
-        + (attendance.getLateCount() + attendance.getLeftEarlyCount()) / 3;
+        + (attendance.getLateCount() + attendance.getLeftEarlyCount() + attendance.getOutingCount())
+            / 3;
 
     attendance.setTotalPresentCount(totalPresentCount);
     attendance.setTotalAbsentCount(totalAbsentCount);
 
-    // KDT 여부 확인 (훈련비 단가 결정)
-    Integer subsidy = mapper.Iskdt(bootcampId) ? 15800 : 5800;
+    Integer totalSessionsCount = attendance.getTotalSessions();
+    // 출석률 계산 (총 결석으로 계산)
+    double rate = ((double) totalAbsentCount / totalSessionsCount) * 100;
+    int roundedRate = (int) Math.round(rate);
 
-    // 단위기간별 훈련비 계산 (최대 20일)
-    int count = Math.min(totalPresentCount, 20);
-    attendance.setTotalSubsidy(count * subsidy);
+    if (roundedRate <= 20) {
+      // KDT 여부 확인 (훈련비 단가 결정)
+      Integer subsidy = mapper.Iskdt(bootcampId) ? 15800 : 5800;
+
+      // 단위기간별 훈련비 계산 (최대 20일)
+      int count = Math.min(totalPresentCount, 20);
+      attendance.setTotalSubsidy(count * subsidy);
+    } else {
+      attendance.setTotalSubsidy(0);
+    }
 
 
     return attendance;
@@ -264,23 +284,33 @@ public class AttendanceService {
       int periodPresent = dto.getPresentCount();
       int periodAnnual = dto.getAnnualCount();
       int periodLeave = dto.getLeaveCount();
+      int periodOuting = dto.getOutingCount();
+      int periodSickLeave = dto.getSickLeaveCount();
 
-      // 단위기간별 지각/조퇴 3회 = 결석 1회
-      int additionalAbsents = (periodLate + periodLeftEarly) / 3;
+
+      // 단위기간별 지각/조퇴/외출 3회 = 결석 1회
+      int additionalAbsents = (periodLate + periodLeftEarly + periodOuting) / 3;
 
       // 단위기간별 실제 출석/결석
       int periodTotalPresent = periodPresent + periodLate + periodLeftEarly + periodAnnual
-          + periodLeave - additionalAbsents;
+          + periodLeave + periodOuting + periodSickLeave - additionalAbsents;
       int periodTotalAbsent = periodAbsent + additionalAbsents;
 
-      // 단위기간별 훈련비 계산 (최대 20일)
-      int count = Math.min(periodTotalPresent, 20);
-      int periodSubsidy = count * subsidyPerDay;
+      Integer totalSessionsCount = dto.getTotalSessions();
+      // 출석률 계산 (총 결석으로 계산)
+      double rate = ((double) periodTotalAbsent / totalSessionsCount) * 100;
+      int roundedRate = (int) Math.round(rate);
+
+      int periodSubsidy = 0;
+      if (roundedRate <= 20) {
+        // 단위기간별 훈련비 계산 (최대 20일)
+        int count = Math.min(periodTotalPresent, 20);
+        periodSubsidy = count * subsidyPerDay;
+      }
 
       dto.setTotalPresentCount(periodTotalPresent);
       dto.setTotalAbsentCount(periodTotalAbsent);
       dto.setTotalSubsidy(periodSubsidy);
-
     }
 
     return periodListAttendance;
@@ -310,6 +340,8 @@ public class AttendanceService {
     int leftEarlyCount = 0;
     int annualCount = 0;
     int leaveCount = 0;
+    int outingCount = 0;
+    int sickLeaveCount = 0;
 
     int totalPresentCount = 0;
     int totalAbsentCount = 0;
@@ -327,18 +359,28 @@ public class AttendanceService {
       int periodPresent = dto.getPresentCount();
       int periodAnnual = dto.getAnnualCount();
       int periodLeave = dto.getLeaveCount();
+      int periodOuting = dto.getOutingCount();
+      int periodSickLeave = dto.getSickLeaveCount();
 
       // 단위기간별 지각/조퇴 3회 = 결석 1회
-      int additionalAbsents = (periodLate + periodLeftEarly) / 3;
+      int additionalAbsents = (periodLate + periodLeftEarly + periodOuting) / 3;
 
       // 단위기간별 실제 출석/결석
       int periodTotalPresent = periodPresent + periodLate + periodLeftEarly + periodAnnual
-          + periodLeave - additionalAbsents;
+          + periodLeave + periodOuting + periodSickLeave - additionalAbsents;
       int periodTotalAbsent = periodAbsent + additionalAbsents;
 
-      // 단위기간별 훈련비 계산 (최대 20일)
-      int count = Math.min(periodTotalPresent, 20);
-      int periodSubsidy = count * subsidyPerDay;
+      Integer totalSessionsCount = dto.getTotalSessions();
+      // 출석률 계산 (총 결석으로 계산)
+      double rate = ((double) periodTotalAbsent / totalSessionsCount) * 100;
+      int roundedRate = (int) Math.round(rate);
+
+      int periodSubsidy = 0;
+      if (roundedRate <= 20) {
+        // 단위기간별 훈련비 계산 (최대 20일)
+        int count = Math.min(periodTotalPresent, 20);
+        periodSubsidy = count * subsidyPerDay;
+      }
 
       // 누적합산
       presentCount += periodPresent;
@@ -347,6 +389,8 @@ public class AttendanceService {
       leftEarlyCount += periodLeftEarly;
       annualCount += periodAnnual;
       leaveCount += periodLeave;
+      outingCount += periodOuting;
+      sickLeaveCount += periodSickLeave;
 
       totalPresentCount += periodTotalPresent;
       totalAbsentCount += periodTotalAbsent;
@@ -360,6 +404,9 @@ public class AttendanceService {
     attendance.setLeftEarlyCount(leftEarlyCount);
     attendance.setAnnualCount(annualCount);
     attendance.setLeaveCount(leaveCount);
+    attendance.setOutingCount(outingCount);
+    attendance.setSickLeaveCount(sickLeaveCount);
+
     attendance.setTotalPresentCount(totalPresentCount);
     attendance.setTotalAbsentCount(totalAbsentCount);
     attendance.setTotalSubsidy(totalSubsidy);


### PR DESCRIPTION
## ✨ 이 PR의 목적
- 훈련 지원금을 단위 기간 출석률 80퍼 이하일시 0원으로 설정
- 병가도 훈련기간중 사용횟수가 정해져 있어서 잔여개수 체크

## 📄 작업 내용 요약
- 훈련 지원금을  단위기간 결석률20퍼 넘으면 0원이 되도록 수정
  (단위기간조회, 단위기간리스트조회, 전체기간조회 api수정)
- 출결 등록, 수정시 잔여 병가를 체크할수있는 로직 추가
- 기존 잔여 월차 조회 api에 잔여 병가도 함께 조회할수있도록 추가 (응답DTO도 수정)
- 출석상태(enum)에 외출(outing), 병가(sick_leave) 추가
<img width="206" height="205" alt="image" src="https://github.com/user-attachments/assets/b4f38dfd-d594-45c3-af93-9b6d78cc580d" />


## 📎 Issue 번호
- Close: #68 #66 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 새로운 근태 유형 추가: 외출 및 병가 상태 지원
  * 병가 사용량 및 잔여 정보 조회 기능 추가
  * 근태율 기반 보조금 계산 로직 구현 (20% 이상 부재 시 미지급)

* **Documentation**
  * API 문서 업데이트: 새로운 근태 상태 타입 반영

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->